### PR TITLE
Changes to GridView control behaviour

### DIFF
--- a/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
@@ -178,6 +178,11 @@ namespace XLabs.Forms.Controls
 		/// <returns>System.Int32.</returns>
 		public int RowsInSection (UICollectionView collectionView, nint section)
 		{
+            if (Element.ItemsSource == null)
+            {
+                return 0;
+            }
+
 			return ((ICollection)Element.ItemsSource).Count;
 		}
 

--- a/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
@@ -96,12 +96,27 @@ namespace XLabs.Forms.Controls
 		/// <param name="e">The <see cref="System.ComponentModel.PropertyChangedEventArgs"/> instance containing the event data.</param>
 		private void ElementPropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == "ItemsSource")
-			{
-				var itemsSource = Element.ItemsSource as INotifyCollectionChanged;
-				if (itemsSource != null) {
-					itemsSource.CollectionChanged -= DataCollectionChanged;
-				}
+            switch (e.PropertyName)
+            {
+                case "ItemsSource":
+                    {
+                        var itemsSource = Element.ItemsSource as INotifyCollectionChanged;
+                        if (itemsSource != null)
+                        {
+                            itemsSource.CollectionChanged -= DataCollectionChanged;
+                        }
+                    }
+                    break;
+                case "SelectedItem":
+                    {
+                        if (Element.ItemsSource != null)
+                        {
+                            var selectionIndex = Element.ItemsSource.Cast<object>().ToList().IndexOf(Element.SelectedItem);
+
+                            Control.SelectItem(NSIndexPath.FromIndex((nuint)selectionIndex), false, UICollectionViewScrollPosition.None);
+                        }
+                    }
+                    break;
 			}
 		}
 
@@ -195,7 +210,6 @@ namespace XLabs.Forms.Controls
 		{
 			var item = Element.ItemsSource.Cast<object>().ElementAt(indexPath.Row);
 			Element.InvokeItemSelectedEvent(this, item);
-
 		}
 
 		/// <summary>

--- a/src/Forms/XLabs.Forms/Controls/GridView.cs
+++ b/src/Forms/XLabs.Forms/Controls/GridView.cs
@@ -26,7 +26,12 @@ namespace XLabs.Forms.Controls
 		/// </summary>
 		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create ("ItemsSource", typeof(IEnumerable), typeof(GridView), null, BindingMode.OneWay, null, null, null, null);
 
-		/// <summary>
+        /// <summary>
+        /// The selected item property
+        /// </summary>
+        public static readonly BindableProperty SelectedItemProperty = BindableProperty.Create("SelectedItem", typeof(object), typeof(GridView), null, BindingMode.TwoWay, null, null, null, null);
+        
+        /// <summary>
 		/// The item template property
 		/// </summary>
 		public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create ("ItemTemplate", typeof(DataTemplate), typeof(GridView), null, BindingMode.OneWay, null, null, null, null);
@@ -66,6 +71,22 @@ namespace XLabs.Forms.Controls
 				base.SetValue (GridView.ItemsSourceProperty, value);
 			}
 		}
+
+        /// <summary>
+        /// Gets or sets the selected item.
+        /// </summary>
+        /// <value>The selected item.</value>
+        public object SelectedItem
+        {
+            get
+            {
+                return (object)base.GetValue(GridView.SelectedItemProperty);
+            }
+            set
+            {
+                base.SetValue(GridView.SelectedItemProperty, value);
+            }
+        }
 
 		/// <summary>
 		/// Gets or sets the item template.
@@ -144,6 +165,8 @@ namespace XLabs.Forms.Controls
 		/// <param name="item">Item.</param>
 		public void InvokeItemSelectedEvent (object sender, object item)
 		{
+            this.SelectedItem = item;
+
 			if (this.ItemSelected != null) {
 				this.ItemSelected.Invoke (sender, new EventArgs<object> (item));
 			}


### PR DESCRIPTION
- Fixed an issue where the `RowsInSection` function would crash if the `ItemsSource` collection was wull.
- Added a `SelectedItem` property that can be two-way data bound.