### PR TITLE
Set timestamp in iOS Geolocation

### DIFF
--- a/src/Platform/XLabs.Platform.iOS/Services/Geolocation/GeolocationSingleUpdateDelegate.cs
+++ b/src/Platform/XLabs.Platform.iOS/Services/Geolocation/GeolocationSingleUpdateDelegate.cs
@@ -180,7 +180,7 @@ namespace XLabs.Platform.Services.Geolocation
 			_position.Latitude = newLocation.Coordinate.Latitude;
 			_position.Longitude = newLocation.Coordinate.Longitude;
 			_position.Speed = newLocation.Speed;
-			//_position.Timestamp = new DateTimeOffset(newLocation.Timestamp);
+			_position.Timestamp = new DateTimeOffset((DateTime)newLocation.Timestamp);
 
 			_haveLocation = true;
 

--- a/src/Platform/XLabs.Platform.iOS/Services/Geolocation/Geolocator.cs
+++ b/src/Platform/XLabs.Platform.iOS/Services/Geolocation/Geolocator.cs
@@ -377,7 +377,7 @@ namespace XLabs.Platform.Services.Geolocation
 				p.Speed = location.Speed;
 			}
 
-			//p.Timestamp = new DateTimeOffset(location.Timestamp);
+			p.Timestamp = new DateTimeOffset((DateTime)location.Timestamp);
 
 			_position = p;
 


### PR DESCRIPTION
Reenable the timestamp in the position data after migrating to the unified project.