### PR TITLE
Fixed problem with NinjectContainer regarding self registering types

### DIFF
--- a/src/IOC/XLabs.Ioc.Ninject/NinjectContainer.cs
+++ b/src/IOC/XLabs.Ioc.Ninject/NinjectContainer.cs
@@ -63,7 +63,10 @@ namespace XLabs.Ioc.Ninject
             where T : class
             where TImpl : class, T
         {
-            this.kernel.Bind<T, TImpl>();
+			if (typeof(T) == typeof(TImpl))
+				this.kernel.Bind<T>().ToSelf();
+			else
+				this.kernel.Bind<T, TImpl>();
             return this;
         }
 


### PR DESCRIPTION
Currently any types registering to themselves causes a runtime NullReferenceException within Ninject when you try to resolve them.

I've added a check in NinjectContainer register method to ensure self registering types are correctly registered. 