### PR TITLE
Revert "Fixes to ExtendedLabel, remove font related properties"

### DIFF
--- a/Samples/XLabs.Sample/Pages/Controls/ExtendedLabelPage.xaml
+++ b/Samples/XLabs.Sample/Pages/Controls/ExtendedLabelPage.xaml
@@ -13,19 +13,62 @@
 			<controls:ExtendedLabel
                 Text="Plain unspecified Extended Label" HorizontalOptions="StartAndExpand" />
 			<controls:ExtendedLabel
-                FontSize="30"
-                Text="Text with strikethrough"
+                Text="Text with strikethrough - no font or size size specified"
                 IsStrikeThrough="True"
                 HorizontalOptions="StartAndExpand" />
-      <controls:ExtendedLabel
-                Text="Text with IsUnderline"
-                IsUnderline="True"
+			<controls:ExtendedLabel
+                Text="Text with strikethrough size 14"
+                IsStrikeThrough="True"
+                FontSize="14"
                 HorizontalOptions="StartAndExpand" />
 			<controls:ExtendedLabel
-                Text="Text with IsDropShadow"
-                IsDropShadow="True"
+                Text="Text with strikethrough 20"
+                IsStrikeThrough="True"
+                FontSize="20"
                 HorizontalOptions="StartAndExpand" />
-			
+			<controls:ExtendedLabel
+                Text="This uses 'FontName' = 'Open 24 Display St' set in XAML and 'FriendlyFontName' properties, size 20"
+                FontName="Open 24 Display St"
+                FriendlyFontName="Open 24 Display St"
+                FontSize="20"
+                HorizontalOptions="StartAndExpand" />
+			<controls:ExtendedLabel
+                Text="As above, but now with Strikethrough"
+                FontName="Open 24 Display St"
+                FriendlyFontName="Open 24 Display St"
+                FontSize="20"
+                IsStrikeThrough="True"
+                HorizontalOptions="StartAndExpand" />
+			<controls:ExtendedLabel
+                Text="This uses 'FontName' = 'Open 24 Display St.ttf'. Size 14"
+                FontName="Open 24 Display St"
+                FriendlyFontName="Open 24 Display St"
+                FontSize="14"
+                HorizontalOptions="StartAndExpand" />
+			<controls:ExtendedLabel
+              Text="This uses 'FontName' = 'Open 24 Display St.ttf'. Size is Xamarin Medium"
+              FontName="Open 24 Display St"
+              FriendlyFontName="Open 24 Display St"
+              Font="Medium"
+              HorizontalOptions="StartAndExpand" />
+			<controls:ExtendedLabel
+              Text="This uses 'FontName' = 'Open 24 Display St.ttf'. Size is Xamarin Large"
+              FontName="Open 24 Display St"
+              FriendlyFontName="Open 24 Display St"
+              Font="Large"
+              HorizontalOptions="StartAndExpand" />
+			<controls:ExtendedLabel
+                Text="This 'FontName' = 'CODE2000', but font does NOT exist, so should default to the system font."
+                FontName="CODE2000"
+                FriendlyFontName="Code2000"
+                FontSize="14"
+                HorizontalOptions="StartAndExpand" />
+			<controls:ExtendedLabel
+                Text="This uses a custom font set xaml using obsolete properties 'FontNameAndroid', 'FontNameIOS'"
+                FontNameAndroid="Open 24 Display St.ttf"
+                FontNameIOS="Open 24 Display St"
+                FontSize="20"
+                HorizontalOptions="StartAndExpand" />
 		</StackLayout>
 		<!-- </ScrollView> -->
 	</ContentPage.Content>

--- a/Samples/XLabs.Sample/Pages/Controls/ExtendedLabelPage.xaml.cs
+++ b/Samples/XLabs.Sample/Pages/Controls/ExtendedLabelPage.xaml.cs
@@ -13,6 +13,27 @@
 
 			BindingContext = ViewModelLocator.Main;
 
+			var label = new ExtendedLabel
+			{
+				Text = "From code, using Device.OnPlatform, Underlined",
+				FontName = "Open 24 Display St.ttf",
+				FriendlyFontName = Device.OnPlatform("", "", "Open 24 Display St"),
+				IsUnderline = true,
+				FontSize = 22,
+			};
+
+			var label2 = new ExtendedLabel
+			{
+				Text = "From code, Strikethrough",
+				FontName = "Open 24 Display St.ttf",
+				FriendlyFontName = Device.OnPlatform("", "", "Open 24 Display St"),
+				IsUnderline = false,
+				IsStrikeThrough = true,
+				FontSize = 22,
+			};
+
+			var font = Font.OfSize("Open 24 Display St", 22);
+
 			var label3 = new ExtendedLabel
 			{
 				Text = "From code, Strikethrough and using Font property",
@@ -33,9 +54,12 @@
 				Text = "Standard Label created using code",
 			};
 
-		
+			label3.Font = font;
+
 			stkRoot.Children.Add(label4);
 			stkRoot.Children.Add(label3);
+			stkRoot.Children.Add(label2);
+			stkRoot.Children.Add(label);
 			stkRoot.Children.Add(label5);
 		}
 	}

--- a/src/Forms/XLabs.Forms.Droid/Controls/ExtendedLabel/ExtendedLabelRenderer.cs
+++ b/src/Forms/XLabs.Forms.Droid/Controls/ExtendedLabel/ExtendedLabelRenderer.cs
@@ -35,33 +35,11 @@ namespace XLabs.Forms.Controls
 		{
 			base.OnElementChanged(e);
 
-			if (e.OldElement == null && e.NewElement != null) {
+			var view = (ExtendedLabel)Element;
+			var control = Control;
 
-				var view = (ExtendedLabel) e.NewElement;
-				var control = Control;
+			UpdateUi(view, control);
 
-				UpdateUi (view, control);
-			}
-
-		}
-
-		/// <summary>
-		/// Raises the element property changed event.
-		/// </summary>
-		/// <param name="sender">Sender</param>
-		/// <param name="e">The event arguments</param>
-		protected override void OnElementPropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
-		{
-			base.OnElementPropertyChanged (sender, e);
-
-			if (e.PropertyName == ExtendedLabel.IsUnderlineProperty.PropertyName ||
-				e.PropertyName == ExtendedLabel.IsDropShadowProperty.PropertyName ||
-				e.PropertyName == ExtendedLabel.IsStrikeThroughProperty.PropertyName
-				) {
-				var view = (ExtendedLabel) Element;
-				var control = Control;
-				UpdateUi (view,control);
-			}
 		}
 
 		/// <summary>
@@ -71,8 +49,34 @@ namespace XLabs.Forms.Controls
 		/// <param name="control">The control.</param>
 		void UpdateUi(ExtendedLabel view, TextView control)
 		{
-			if (view == null || control == null)
-				return;
+			if(!string.IsNullOrEmpty(view.FontName))
+			{
+				string filename = view.FontName;
+				//if no extension given then assume and add .ttf
+				if(filename.LastIndexOf(".", System.StringComparison.Ordinal) != filename.Length - 4)
+				{
+					filename = string.Format("{0}.ttf", filename);
+				}
+				control.Typeface = TrySetFont(filename);
+			}
+
+			//======= This is for backward compatability with obsolete attrbute 'FontNameAndroid' ========
+			else if(!string.IsNullOrEmpty(view.FontNameAndroid))
+			{
+				control.Typeface = TrySetFont(view.FontNameAndroid);
+
+			}
+			//====== End of obsolete section ==========================================================
+
+			else if(view.Font != Font.Default)
+			{
+				control.Typeface = view.Font.ToExtendedTypeface(Context);
+			}
+
+			if(view.FontSize > 0)
+			{
+				control.TextSize = (float)view.FontSize;
+			}
 
 			if(view.IsUnderline)
 			{
@@ -84,10 +88,31 @@ namespace XLabs.Forms.Controls
 				control.PaintFlags = control.PaintFlags | PaintFlags.StrikeThruText;
 			}
 
-			if (view.IsDropShadow) {
-				//TODO:: Needs implementation
-			}
+		}
 
+		/// <summary>
+		/// Tries the set font.
+		/// </summary>
+		/// <param name="fontName">Name of the font.</param>
+		/// <returns>Typeface.</returns>
+		private Typeface TrySetFont(string fontName)
+		{
+			try
+			{                
+				return Typeface.CreateFromAsset(Context.Assets, "fonts/" + fontName);
+			} catch(Exception ex)
+			{
+				Console.WriteLine("not found in assets. Exception: {0}", ex);
+				try
+				{
+					return Typeface.CreateFromFile("fonts/" + fontName);
+				} catch(Exception ex1)
+				{
+					Console.WriteLine("not found by file. Exception: {0}", ex1);
+
+					return Typeface.Default;
+				}
+			}
 		}
 	}
 }

--- a/src/Forms/XLabs.Forms.WP8/Controls/ExtendedLabel/ExtendedLabelRenderer.cs
+++ b/src/Forms/XLabs.Forms.WP8/Controls/ExtendedLabel/ExtendedLabelRenderer.cs
@@ -29,29 +29,8 @@ namespace XLabs.Forms.Controls
 		{
 			base.OnElementChanged(e);
 
-			if (e.NewElement != null) {
-				var view = (ExtendedLabel) e.NewElement;
-				UpdateUi (view, Control);
-			}
-		}
-
-		/// <summary>
-		/// Raises the element property changed event.
-		/// </summary>
-		/// <param name="sender">Sender</param>
-		/// <param name="e">The event arguments</param>
-		protected override void OnElementPropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
-		{
-			base.OnElementPropertyChanged (sender, e);
-
-			if (e.PropertyName == ExtendedLabel.IsUnderlineProperty.PropertyName ||
-				e.PropertyName == ExtendedLabel.IsDropShadowProperty.PropertyName ||
-				e.PropertyName == ExtendedLabel.IsStrikeThroughProperty.PropertyName
-				) {
-				var view = (ExtendedLabel) Element;
-				var control = Control;
-				UpdateUi (view, control);
-			}
+			var view = (ExtendedLabel) Element;
+			UpdateUi(view, Control);
 		}
 
 
@@ -66,8 +45,9 @@ namespace XLabs.Forms.Controls
 		/// </param>
 		private void UpdateUi(ExtendedLabel view, TextBlock control)
 		{
-			if (view == null || control == null)
-				return;
+			if (view.FontSize > 0)
+				control.FontSize = (float) view.FontSize;
+			//control.FontSize = (view.FontSize > 0) ? (float)view.FontSize : 12.0f;
 
 			////need to do this ahead of font change due to unexpected behaviour if done later.
 			if (view.IsStrikeThrough)
@@ -105,14 +85,38 @@ namespace XLabs.Forms.Controls
 
 			}
 
-			if (view.IsUnderline)
-				control.TextDecorations = TextDecorations.Underline;
+			if (!string.IsNullOrEmpty(view.FontName))
+			{
+				string filename = view.FontName;
+				//if no extension given then assume and add .ttf
+				if (filename.LastIndexOf(".", StringComparison.Ordinal) != filename.Length - 4)
+				{
+					filename = string.Format("{0}.ttf", filename);
+				}
 
-			if (view.IsDropShadow) {
-				//TODO: Implement dropshadow
+			    if (LocalFontFileExists(filename)) //only substitute custom font if exists
+			    {
+			        control.FontFamily =
+			            new FontFamily(string.Format(@"\Assets\Fonts\{0}#{1}", filename,
+			                string.IsNullOrEmpty(view.FriendlyFontName)
+			                    ? filename.Substring(0, filename.Length - 4)
+			                    : view.FriendlyFontName));
+			    }
 			}
 
+			if (view.IsUnderline)
+				control.TextDecorations = TextDecorations.Underline;
 		}
 
+		/// <summary>
+		/// Checks if a local resource font file exists
+		/// </summary>
+		/// <param name="filename">the filename including extension, but not path</param>
+		/// <returns></returns>
+		private static bool LocalFontFileExists(string filename)
+		{
+			return
+                System.Windows.Application.GetResourceStream(new Uri(string.Format(@"Assets/Fonts/{0}", filename), UriKind.Relative)) != null;            
+		}
 	}
 }

--- a/src/Forms/XLabs.Forms.iOS/Controls/ExtendedLabel/ExtendedLabelRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/ExtendedLabel/ExtendedLabelRenderer.cs
@@ -28,11 +28,11 @@ namespace XLabs.Forms.Controls
 		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
 		{
 			base.OnElementChanged(e);
-			if (e.NewElement != null) {
-				var view = (ExtendedLabel)e.NewElement;
-				UpdateUi (view, Control);
-			}
-			
+
+			var view = (ExtendedLabel)Element;
+
+			UpdateUi(view, Control);
+			SetPlaceholder(view);
 		}
 
 		/// <summary>
@@ -46,13 +46,25 @@ namespace XLabs.Forms.Controls
 
 			var view = (ExtendedLabel)Element;
 
-			if (e.PropertyName == ExtendedLabel.IsUnderlineProperty.PropertyName ||
-				e.PropertyName == ExtendedLabel.IsDropShadowProperty.PropertyName ||
-				e.PropertyName == ExtendedLabel.IsStrikeThroughProperty.PropertyName
-				) {
-					UpdateUi (view,Control);
+			if (e.PropertyName == Label.TextProperty.PropertyName)
+			{
+				SetPlaceholder(view);
 			}
-			
+
+			if (e.PropertyName == Label.FormattedTextProperty.PropertyName)
+			{
+				SetPlaceholder(view);
+			}
+
+			if (e.PropertyName == ExtendedLabel.PlaceholderProperty.PropertyName)
+			{
+				SetPlaceholder(view);
+			}
+
+			if (e.PropertyName == ExtendedLabel.FormattedPlaceholderProperty.PropertyName)
+			{
+				SetPlaceholder(view);
+			}
 		}
 
 		/// <summary>
@@ -66,8 +78,39 @@ namespace XLabs.Forms.Controls
 		/// </param>
 		private void UpdateUi(ExtendedLabel view, UILabel control)
 		{
-			if (view == null || control == null)
-				return;
+			// Prefer font set through Font property.
+			if (view.Font == Font.Default)
+			{
+				if (view.FontSize > 0)
+				{
+					control.Font = UIFont.FromName(control.Font.Name, (float)view.FontSize);
+				}
+
+				if (!string.IsNullOrEmpty(view.FontName))
+				{
+					var fontName = Path.GetFileNameWithoutExtension(view.FontName);
+
+					var font = UIFont.FromName(fontName, control.Font.PointSize);
+
+					if (font != null)
+					{
+						control.Font = font;
+					}
+				}
+
+				#region ======= This is for backward compatability with obsolete attrbute 'FontNameIOS' ========
+				if (!string.IsNullOrEmpty(view.FontNameIOS))
+				{
+					var font = UIFont.FromName(view.FontNameIOS, (view.FontSize > 0) ? (float)view.FontSize : 12.0f);
+
+					if (font != null)
+					{
+						control.Font = font;
+					}
+				}
+				#endregion ====== End of obsolete section ==========================================================
+			}
+
 			//Do not create attributed string if it is not necesarry
 			if (!view.IsUnderline && !view.IsStrikeThrough && !view.IsDropShadow)
 			{
@@ -97,15 +140,37 @@ namespace XLabs.Forms.Controls
 				control.TextColor = view.TextColor.ToUIColor();
 			}
 
-		
 			control.AttributedText = new NSMutableAttributedString(control.Text,
 																   control.Font,
 																   underlineStyle: underline,
 																   strikethroughStyle: strikethrough,
-																   shadow: dropShadow);
-		
+																   shadow: dropShadow); ;
 		}
 
+		private void SetPlaceholder(ExtendedLabel view)
+		{
+			if (!string.IsNullOrWhiteSpace(view.Text))
+			{
+				var formattedString = view.FormattedText ?? view.Text;
+
+				Control.AttributedText = formattedString.ToAttributed(view.Font, view.TextColor);
+
+				LayoutSubviews();
+
+				return;
+			}
+
+			if (string.IsNullOrWhiteSpace(view.Placeholder) && view.FormattedPlaceholder == null)
+			{
+				return;
+			}
+
+			var formattedPlaceholder = view.FormattedPlaceholder ?? view.Placeholder;
+
+			Control.AttributedText = formattedPlaceholder.ToAttributed(view.Font, view.TextColor);
+
+			LayoutSubviews();
+		}
 	}
 }
 

--- a/src/Forms/XLabs.Forms/Controls/ExtendedLabel.cs
+++ b/src/Forms/XLabs.Forms/Controls/ExtendedLabel.cs
@@ -16,6 +16,127 @@ namespace XLabs.Forms.Controls
 		}
 
 		/// <summary>
+		/// The font size property
+		/// </summary>
+		public static readonly BindableProperty FontSizeProperty =
+			BindableProperty.Create<ExtendedLabel, double>(
+				p => p.FontSize, -1);
+
+		/// <summary>
+		/// Gets or sets the size of the font.
+		/// </summary>
+		/// <value>The size of the font.</value>
+		public double FontSize
+		{
+			get
+			{
+				return (double)GetValue(FontSizeProperty);
+			}
+			set
+			{
+				SetValue(FontSizeProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// The font name android property.
+		/// </summary>
+		[Obsolete("This is now obsolete. Please rather use FontName and FriendlyFontName to cover all platforms.")]
+		public static readonly BindableProperty FontNameAndroidProperty =
+			BindableProperty.Create<ExtendedLabel, string>(
+				p => p.FontNameAndroid, string.Empty);
+
+		/// <summary>
+		/// Gets or sets the font name android.
+		/// </summary>
+		/// <value>The font name android.</value>
+		[Obsolete("This is now obsolete. Please rather use FontName and FriendlyFontName to cover all platforms.")]
+		public string FontNameAndroid
+		{
+			get
+			{
+				return (string)GetValue(FontNameAndroidProperty);
+			}
+			set
+			{
+				SetValue(FontNameAndroidProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// The font name ios property.
+		/// </summary>
+		[Obsolete("This is now obsolete. Please rather use FontName and FriendlyFontName to cover all platforms.")]
+		public static readonly BindableProperty FontNameIosProperty =
+			BindableProperty.Create<ExtendedLabel, string>(
+				p => p.FontNameIOS, string.Empty);
+
+		/// <summary>
+		/// Gets or sets the font name ios.
+		/// </summary>
+		/// <value>The font name ios.</value>
+		[Obsolete]
+		public string FontNameIOS
+		{
+			get
+			{
+				return (string)GetValue(FontNameIosProperty);
+			}
+			set
+			{
+				SetValue(FontNameIosProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// The font name property.
+		/// </summary>
+		public static readonly BindableProperty FontNameProperty =
+			BindableProperty.Create<ExtendedLabel, string>(
+				p => p.FontName, string.Empty);
+
+		/// <summary>
+		/// Gets or sets the name of the font file including extension. If no extension given then ttf is assumed.
+		/// Fonts need to be included in projects accoring to the documentation.
+		/// </summary>
+		/// <value>The full name of the font file including extension.</value>
+		public string FontName
+		{
+			get
+			{
+				return (string)GetValue(FontNameProperty);
+			}
+			set
+			{
+				SetValue(FontNameProperty, value);
+			}
+		}
+
+		/// <summary>
+		/// The friendly font name property. This can be found on the first line of the font or in the font preview. 
+		/// This is only required on Windows Phone. If not given then the file name excl. the extension is used.
+		/// </summary>
+		public static readonly BindableProperty FriendlyFontNameProperty =
+			BindableProperty.Create<ExtendedLabel, string>(
+				p => p.FriendlyFontName, string.Empty);
+
+		/// <summary>
+		/// Gets or sets the name of the font.
+		/// </summary>
+		/// <value>The name of the font.</value>
+		public string FriendlyFontName
+		{
+			get
+			{
+				return (string)GetValue(FriendlyFontNameProperty);
+			}
+			set
+			{
+				SetValue(FriendlyFontNameProperty, value);
+			}
+		}
+
+		/// <summary>
 		/// The is underlined property.
 		/// </summary>
 		public static readonly BindableProperty IsUnderlineProperty =


### PR DESCRIPTION
Reverts XLabs/Xamarin-Forms-Labs#672

According to latest XF implementation, there is no way to use custom font in Android without a CustomRenderer. Therefore FontName and FontFriendlyName should not be removed and should be added back.