### PR TITLE
Fix checkbox error when pop a page asynchronously

### DIFF
--- a/src/Forms/XLabs.Forms.iOS/Controls/CheckBox/CheckBoxRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/CheckBox/CheckBoxRenderer.cs
@@ -28,6 +28,8 @@ namespace XLabs.Forms.Controls
 		{
 			base.OnElementChanged(e);
 
+			if (Element == null) return;
+
 			BackgroundColor = Element.BackgroundColor.ToUIColor();
 
 			if (Control == null)


### PR DESCRIPTION
Fixes #649.

I also provided two projects with this error:
- https://github.com/pauloortins/CheckboxNotAppearingiOS is an example project using the newest version of both Xamarin.Forms (1.4.0) and XLabs (2.0.5546.35667).
- https://github.com/pauloortins/Xamarin-Forms-Labs/tree/checkbox-error, is the error occurring in the XLabs Project, I created a new page in the controls section called CheckBoxWithError, so you can see it happening.
