### PR TITLE
Fix for FontSize not working

### DIFF
--- a/src/Forms/XLabs.Forms.iOS/Controls/CheckBox/CheckBoxRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/CheckBox/CheckBoxRenderer.cs
@@ -97,16 +97,16 @@ namespace XLabs.Forms.Controls
 		/// </summary>
 		private void UpdateFont()
 		{
-			if (string.IsNullOrEmpty(Element.FontName))
-			{
-				return;
-			}
-
-			var font = UIFont.FromName(Element.FontName, (Element.FontSize > 0) ? (float)Element.FontSize : 12.0f);
-
-			if (font != null)
-			{
-				Control.Font = font;
+			if (!string.IsNullOrEmpty (Element.FontName)) {
+				var font = UIFont.FromName (Element.FontName, (Element.FontSize > 0) ? (float)Element.FontSize : 12.0f);
+				if (font != null) {
+					Control.Font = font;
+				}
+			} else if (Element.FontSize > 0) {
+				var font = UIFont.FromName (Control.Font.Name, (float)Element.FontSize);
+				if (font != null) {
+					Control.Font = font;
+				}
 			}
 		}
 


### PR DESCRIPTION
When specified in XAML FontSize isn’t applied if FontName hasn’t been
specified.

I'm not sure if this is the correct fix for this or not. It does work when used with the Samples app.