### PR TITLE
InvalidCastException in Sample app is fixed on Android

### DIFF
--- a/Samples/XLabs.Sample/App.cs
+++ b/Samples/XLabs.Sample/App.cs
@@ -292,24 +292,27 @@ namespace XLabs.Sample
 
             listView.ItemTemplate.SetBinding(TextCell.TextProperty, "Key");
 
-            listView.ItemSelected += async (sender, e) =>
+            listView.ItemTapped += async (sender, e) =>
             {
+                var list = sender as ListView;
+                if (list != null)
+                {
+                    list.SelectedItem = null;
+                }
+
                 Type result = null;
 
                 // This is actually some type of bug with Xamarin.
                 // On iOS the SortedDiectionary entries are DictionaryEntries
                 // on WP, they are KeyValuePairs.
                 // Using the wrong type causes a casting exception.
-                switch (Device.OS)
+                if (e.Item is DictionaryEntry)
                 {
-                    case TargetPlatform.Android:
-                    case TargetPlatform.iOS:
-                        var item = (DictionaryEntry) e.SelectedItem;
-                        result = (Type)item.Value;
-                        break;
-                    case TargetPlatform.WinPhone:
-                        result = ((KeyValuePair<string, Type>)e.SelectedItem).Value;
-                        break;
+                    result = ((DictionaryEntry)e.Item).Value as Type;
+                }
+                else
+                {
+                    result = ((KeyValuePair<string, Type>)e.Item).Value;
                 }
 
                 await ShowPage(mainPage, result);


### PR DESCRIPTION
It seems that entry of SortedDictionary is KeyValuePair on Android. So, dependence on platform is replaced on type check. This should help to avoid InvalidCastException even if current behavior will be changed in a future.
Additionally, deselecting of tapped item is added, to avoid selection on returning back from a control page.