### PR TITLE
I removed generics from RepeaterView

### DIFF
--- a/Samples/XLabs.Sample.Droid/XLabs.Sample.Droid.csproj
+++ b/Samples/XLabs.Sample.Droid/XLabs.Sample.Droid.csproj
@@ -14,8 +14,7 @@
     <AndroidApplication>True</AndroidApplication>
     <AssemblyName>XLabs.Sample.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>
-    </TargetFrameworkVersion>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\src\Xamarin.Forms.Labs\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>397312ac</NuGetPackageImportStamp>

--- a/Samples/XLabs.Sample/App.cs
+++ b/Samples/XLabs.Sample/App.cs
@@ -70,6 +70,7 @@ namespace XLabs.Sample
             ViewFactory.Register<CacheServicePage, CacheServiceViewModel>();
             ViewFactory.Register<SoundPage, SoundServiceViewModel>();
             ViewFactory.Register<RepeaterViewPage, RepeaterViewViewModel>();
+            ViewFactory.Register<RepeaterViewTemplateSelectorPage, RepeaterViewTemplateSelectorViewModel>();
             ViewFactory.Register<WaveRecorderPage, WaveRecorderViewModel>();
 
             var mainTab = new ExtendedTabbedPage()
@@ -228,6 +229,7 @@ namespace XLabs.Sample
                 {"Popup", typeof(PopupPage)},
                 {"RadioButton",typeof(RadioButtonPage)},
                 {"RepeaterView", typeof(RepeaterViewPage)},
+                {"RepeaterViewTemplateSelector", typeof(RepeaterViewTemplateSelectorPage)},
                 {"Segment", typeof(SegmentPage)},
                 {"Separator", typeof(SeparatorPage)},
                 {"WebImage", typeof(WebImagePage)},

--- a/Samples/XLabs.Sample/Pages/Controls/RepeaterViewPage.cs
+++ b/Samples/XLabs.Sample/Pages/Controls/RepeaterViewPage.cs
@@ -18,7 +18,7 @@
 			var viewModel = new RepeaterViewViewModel();
 			BindingContext = viewModel;
 
-			var repeater = new RepeaterView<Thing>
+			var repeater = new RepeaterView
 			{
 				Spacing = 10,
 				ItemsSource = viewModel.Things,

--- a/Samples/XLabs.Sample/Pages/Controls/RepeaterViewTemplateSelectorPage.cs
+++ b/Samples/XLabs.Sample/Pages/Controls/RepeaterViewTemplateSelectorPage.cs
@@ -1,0 +1,131 @@
+﻿namespace XLabs.Sample.Pages.Controls
+{
+    using Xamarin.Forms;
+
+    using XLabs.Forms.Controls;
+    using XLabs.Sample.ViewModel;
+
+    /// <summary>
+    /// Class RepeaterViewPage.
+    /// </summary>
+    public class RepeaterViewTemplateSelectorPage : ContentPage
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="RepeaterViewPage"/> class.
+        /// </summary>
+        public RepeaterViewTemplateSelectorPage()
+		{
+			var viewModel = new RepeaterViewTemplateSelectorViewModel();
+			BindingContext = viewModel;
+
+		    var thingTempate = new DataTemplate(() =>
+		    {
+		        var nameLabel = new Label {Font = Font.SystemFontOfSize(NamedSize.Medium)};
+                nameLabel.SetBinding(Label.TextProperty, RepeaterViewTemplateSelectorViewModel.ThingsNamePropertyName);
+
+		        var descriptionLabel = new Label {Font = Font.SystemFontOfSize(NamedSize.Small)};
+                descriptionLabel.SetBinding(Label.TextProperty, RepeaterViewTemplateSelectorViewModel.ThingsDescriptionPropertyName);
+
+		        ViewCell cell = new ViewCell
+		        {
+		            View = new StackLayout
+		            {
+		                Spacing = 0,
+		                Children =
+		                {
+		                    nameLabel,
+		                    descriptionLabel
+		                }
+		            }
+		        };
+
+		        return cell;
+		    });
+            // Make the Thing2 template have green text
+            var thing2Tempate = new DataTemplate(() =>
+		    {
+		        var nameLabel = new Label {Font = Font.SystemFontOfSize(NamedSize.Medium), TextColor = Color.Green};
+                nameLabel.SetBinding(Label.TextProperty, RepeaterViewTemplateSelectorViewModel.ThingsNamePropertyName);
+
+		        var descriptionLabel = new Label {Font = Font.SystemFontOfSize(NamedSize.Small), TextColor = Color.Green};
+                descriptionLabel.SetBinding(Label.TextProperty, RepeaterViewTemplateSelectorViewModel.ThingsDescriptionPropertyName);
+
+		        ViewCell cell = new ViewCell
+		        {
+		            View = new StackLayout
+		            {
+		                Spacing = 0,
+		                Children =
+		                {
+		                    nameLabel,
+		                    descriptionLabel
+		                }
+		            }
+		        };
+
+		        return cell;
+		    });
+
+            var templateSelector = new TemplateSelector();
+            templateSelector.Add(thingTempate, typeof(Thing));
+            templateSelector.Add(thing2Tempate, typeof(Thing2));
+
+			var repeater = new RepeaterView
+			{
+				Spacing = 10,
+				ItemsSource = viewModel.Things,
+                ItemTemplateSelector = templateSelector
+			};
+
+			var removeButton = new Button
+			{
+				Text = "Remove 1st Item",      
+				HorizontalOptions = LayoutOptions.Start
+			};
+
+            removeButton.SetBinding(Button.CommandProperty, RepeaterViewTemplateSelectorViewModel.RemoveFirstItemCommandName);
+
+			var addButton = new Button
+			{
+				Text = "Add New Thing",
+				HorizontalOptions = LayoutOptions.Start
+			};
+
+            addButton.SetBinding(Button.CommandProperty, RepeaterViewTemplateSelectorViewModel.AddThingItemCommandName);
+
+            var addThing2Button = new Button
+            {
+                Text = "Add New Thing2",
+                HorizontalOptions = LayoutOptions.Start
+            };
+
+            addThing2Button.SetBinding(Button.CommandProperty, RepeaterViewTemplateSelectorViewModel.AddThing2ItemCommandName);
+
+			Content = new StackLayout
+			{
+				Padding = 20,
+				Spacing = 5,
+				Children = 
+				{
+					new Label 
+					{ 
+						Text = "RepeaterView Demo", 
+						Font = Font.SystemFontOfSize(NamedSize.Large)
+					},
+                    new Label
+                    {
+                        Text=" with Template Selector",
+						Font = Font.SystemFontOfSize(NamedSize.Medium),
+                        FontAttributes = FontAttributes.Italic
+                    },
+					repeater,
+					removeButton,
+					addButton,
+                    addThing2Button
+				}
+			};
+
+			viewModel.LoadData();
+		}
+    }
+}

--- a/Samples/XLabs.Sample/ViewModel/RepeaterViewTemplateSelectorViewModel.cs
+++ b/Samples/XLabs.Sample/ViewModel/RepeaterViewTemplateSelectorViewModel.cs
@@ -1,0 +1,169 @@
+﻿namespace XLabs.Sample.ViewModel
+{
+	using System.Collections.ObjectModel;
+
+	using Xamarin.Forms;
+
+	using XLabs.Forms.Mvvm;
+	using XLabs.Sample.Pages.Mvvm;
+
+	/// <summary>
+	/// Class RepeaterViewViewModel.
+	/// </summary>
+	[ViewType(typeof(MvvmSamplePage))]
+	public class RepeaterViewTemplateSelectorViewModel : XLabs.Forms.Mvvm.ViewModel
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RepeaterViewViewModel"/> class.
+		/// </summary>
+        public RepeaterViewTemplateSelectorViewModel()
+		{
+			Things.CollectionChanged += ThingsCollectionChanged;
+		}
+
+		/// <summary>
+		/// Handles the CollectionChanged event of the Things control.
+		/// </summary>
+		/// <param name="sender">The source of the event.</param>
+		/// <param name="e">The <see cref="System.Collections.Specialized.NotifyCollectionChangedEventArgs"/> instance containing the event data.</param>
+		void ThingsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+            RemoveFirstItem.ChangeCanExecute();
+            AddThingItem.ChangeCanExecute();
+            AddThing2Item.ChangeCanExecute();
+		}
+
+		/// <summary>
+		/// The _things
+		/// </summary>
+		private ObservableCollection<Thing> _things =  new ObservableCollection<Thing>();
+		/// <summary>
+		/// The things property name
+		/// </summary>
+		public const string ThingsPropertyName = "Things";
+		/// <summary>
+		/// The things name property name
+		/// </summary>
+		public const string ThingsNamePropertyName = "Name";
+		/// <summary>
+		/// The things description property name
+		/// </summary>
+		public const string ThingsDescriptionPropertyName = "Description";
+		/// <summary>
+		/// Gets or sets the things.
+		/// </summary>
+		/// <value>The things.</value>
+		public ObservableCollection<Thing> Things
+		{
+			get { return _things; }
+			set 
+			{ 
+				SetProperty(ref _things, value);
+			}
+		}
+
+		/// <summary>
+		/// The _next item number
+		/// </summary>
+		private int _nextItemNumber;
+		/// <summary>
+		/// The next item number property name
+		/// </summary>
+		public const string NextItemNumberPropertyName = "NextItemNumber";
+		/// <summary>
+		/// Gets or sets the next item number.
+		/// </summary>
+		/// <value>The next item number.</value>
+		public int NextItemNumber
+		{
+			get { return _nextItemNumber; }
+			set { SetProperty(ref _nextItemNumber, value); }
+		}
+
+		/// <summary>
+		/// The _remove first item
+		/// </summary>
+		private Command _removeFirstItem;
+		/// <summary>
+		/// The remove first item command name
+		/// </summary>
+		public const string RemoveFirstItemCommandName = "RemoveFirstItem";
+		/// <summary>
+		/// Gets the remove first item.
+		/// </summary>
+		/// <value>The remove first item.</value>
+		public Command RemoveFirstItem
+		{
+			get 
+			{ 
+				return _removeFirstItem ?? (_removeFirstItem = new Command(() =>
+				{
+					Things.RemoveAt(0);                    
+				}, 
+				() => Things.Count > 0)); 
+			}
+		}
+
+		/// <summary>
+		/// The _add item
+		/// </summary>
+		private Command _addThingItem;
+		/// <summary>
+		/// The add item command name
+		/// </summary>
+		public const string AddThingItemCommandName = "AddThingItem";
+		/// <summary>
+		/// Gets the add item.
+		/// </summary>
+		/// <value>The add item.</value>
+		public Command AddThingItem
+		{
+			get
+			{
+				return _addThingItem ?? (_addThingItem = new Command(() =>
+				{
+					Things.Add(new Thing { Name = string.Format("Thing {0}", NextItemNumber), Description = string.Format("This is thing #{0}", NextItemNumber++) });
+				},
+				() => Things.Count < 5));
+			}
+		}
+
+        /// <summary>
+        /// The _add item
+        /// </summary>
+        private Command _addThing2Item;
+        /// <summary>
+        /// The add item command name
+        /// </summary>
+        public const string AddThing2ItemCommandName = "AddThing2Item";
+
+        public Command AddThing2Item
+        {
+            get
+            {
+                return _addThing2Item ?? (_addThing2Item = new Command(() =>
+                {
+                    Things.Add(new Thing2 { Name = string.Format("Thing {0}", NextItemNumber), Description = string.Format("This is thing #{0}", NextItemNumber++) });
+                },
+                () => Things.Count < 5));
+            }
+        }
+
+		/// <summary>
+		/// Loads the data.
+		/// </summary>
+		public void LoadData()
+		{
+			Things.Add(new Thing { Name = "Thing 1", Description = "This is thing #1." });
+			Things.Add(new Thing2 { Name = "Thing 2", Description = "This is thing #2." });
+			NextItemNumber = 3;
+		}
+	}
+
+	/// <summary>
+	/// Class Thing2
+	/// </summary>
+	public class Thing2 : Thing
+	{
+	}
+}

--- a/Samples/XLabs.Sample/XLabs.Sample.csproj
+++ b/Samples/XLabs.Sample/XLabs.Sample.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Pages\Controls\RadioButtonPage.xaml.cs">
       <DependentUpon>RadioButtonPage.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Pages\Controls\RepeaterViewTemplateSelectorPage.cs" />
     <Compile Include="Pages\Controls\RepeaterViewPage.cs" />
     <Compile Include="Pages\Controls\ExtendedSliderPage.cs" />
     <Compile Include="Pages\Controls\SegmentedControlViewPage.xaml.cs">
@@ -126,6 +127,7 @@
     <Compile Include="ViewModel\CameraViewModel.cs" />
     <Compile Include="ViewModel\GestureSampleVM.cs" />
     <Compile Include="ViewModel\MainViewModel.cs" />
+    <Compile Include="ViewModel\RepeaterViewTemplateSelectorViewModel.cs" />
     <Compile Include="ViewModel\RepeaterViewViewModel.cs" />
     <Compile Include="ViewModel\ViewModelLocator.cs" />
     <Compile Include="Pages\Controls\ExtendedLabelPage.xaml.cs">

--- a/src/Forms/XLabs.Forms/Controls/RepeaterView.cs
+++ b/src/Forms/XLabs.Forms/Controls/RepeaterView.cs
@@ -1,8 +1,7 @@
 ﻿namespace XLabs.Forms.Controls
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
+    using System.Collections;
     using System.Windows.Input;
     using Xamarin.Forms;
     using XLabs.Exceptions;
@@ -11,15 +10,14 @@
     /// Low cost control to display a set of clickable items
     /// </summary>
     /// <typeparam name="T">The Type of viewmodel</typeparam>
-    public class RepeaterView<T> : StackLayout
-        where T : class
+    public class RepeaterView : StackLayout
     {
         /// <summary>
         /// Definition for <see cref="ItemTemplate"/>
         /// </summary>
         /// Element created at 15/11/2014,3:11 PM by Charles
         public static readonly BindableProperty ItemTemplateProperty =
-            BindableProperty.Create<RepeaterView<T>, DataTemplate>(
+            BindableProperty.Create<RepeaterView, DataTemplate>(
                 p => p.ItemTemplate,
                 default(DataTemplate));
 
@@ -28,9 +26,9 @@
         /// </summary>
         /// Element created at 15/11/2014,3:11 PM by Charles
         public static readonly BindableProperty ItemsSourceProperty =
-            BindableProperty.Create<RepeaterView<T>, IEnumerable<T>>(
+            BindableProperty.Create<RepeaterView, IEnumerable>(
                 p => p.ItemsSource,
-                Enumerable.Empty<T>(),
+                null,
                 BindingMode.OneWay,
                 null,
                 ItemsChanged);
@@ -40,15 +38,15 @@
         /// </summary>
         /// Element created at 15/11/2014,3:11 PM by Charles
         public static BindableProperty ItemClickCommandProperty =
-            BindableProperty.Create<RepeaterView<T>, ICommand>(x => x.ItemClickCommand, null);
+            BindableProperty.Create<RepeaterView, ICommand>(x => x.ItemClickCommand, null);
 
         /// <summary>
-        /// Definition for <see cref="TemplateSelector"/>
+        /// Definition for <see cref="ItemTemplateSelector"/>
         /// </summary>
         /// Element created at 15/11/2014,3:12 PM by Charles
-        public static readonly BindableProperty TemplateSelectorProperty =
-            BindableProperty.Create<RepeaterView<T>, TemplateSelector>(
-                x => x.TemplateSelector,
+        public static readonly BindableProperty ItemTemplateSelectorProperty =
+            BindableProperty.Create<RepeaterView, TemplateSelector>(
+                x => x.ItemTemplateSelector,
                 default(TemplateSelector));
 
         /// <summary>
@@ -83,19 +81,19 @@
         /// <summary>Gets or sets the items source.</summary>
         /// <value>The items source.</value>
         /// Element created at 15/11/2014,3:13 PM by Charles
-        public IEnumerable<T> ItemsSource
+        public IEnumerable ItemsSource
         {
-            get { return (IEnumerable<T>)GetValue(ItemsSourceProperty); }
+            get { return (IEnumerable)GetValue(ItemsSourceProperty); }
             set { SetValue(ItemsSourceProperty, value); }
         }
 
         /// <summary>Gets or sets the template selector.</summary>
         /// <value>The template selector.</value>
         /// Element created at 15/11/2014,3:13 PM by Charles
-        public TemplateSelector TemplateSelector
+        public TemplateSelector ItemTemplateSelector
         {
-            get { return (TemplateSelector)GetValue(TemplateSelectorProperty); }
-            set { SetValue(TemplateSelectorProperty, value); }
+            get { return (TemplateSelector)GetValue(ItemTemplateSelectorProperty); }
+            set { SetValue(ItemTemplateSelectorProperty, value); }
         }
 
         /// <summary>Gets or sets the item click command.</summary>
@@ -110,7 +108,7 @@
         /// <summary>
         /// The item template property
         /// This can be used on it's own or in combination with 
-        /// the <see cref="TemplateSelector"/>
+        /// the <see cref="ItemTemplateSelector"/>
         /// </summary>
         /// Element created at 15/11/2014,3:10 PM by Charles
         public DataTemplate ItemTemplate
@@ -125,7 +123,7 @@
         /// </summary>
         /// <param name="view">The visual view object</param>
         /// <param name="model">The item being added</param>
-        protected virtual void NotifyItemAdded(View view, T model)
+        protected virtual void NotifyItemAdded(View view, object model)
         {
             if (ItemCreated != null)
             {
@@ -142,7 +140,7 @@
         protected virtual DataTemplate GetTemplateFor(Type type)
         {
             DataTemplate retTemplate = null;
-            if (TemplateSelector != null) retTemplate = TemplateSelector.TemplateFor(type);
+            if (ItemTemplateSelector != null) retTemplate = ItemTemplateSelector.TemplateFor(type);
             return retTemplate ?? ItemTemplate;
         }
 
@@ -159,7 +157,7 @@
         /// <returns>A View that has been initialized with <see cref="item"/> as it's BindingContext</returns>
         /// <exception cref="InvalidVisualObjectException"></exception>Thrown when the matched datatemplate inflates to an object not derived from either
         /// <see cref="Xamarin.Forms.View"/> or <see cref="Xamarin.Forms.ViewCell"/>
-        protected virtual View ViewFor(T item)
+        protected virtual View ViewFor(object item)
         {
             var template = GetTemplateFor(item.GetType());
             var content = template.CreateContent();
@@ -182,10 +180,10 @@
         /// <param name="newValue">New bound collection</param>
         private static void ItemsChanged(
             BindableObject bindable,
-            IEnumerable<T> oldValue,
-            IEnumerable<T> newValue)
+            IEnumerable oldValue,
+            IEnumerable newValue)
         {
-            var control = bindable as RepeaterView<T>;
+            var control = bindable as RepeaterView;
             if (control == null)
                 throw new Exception(
                     "Invalid bindable object passed to ReapterView::ItemsChanged expected a ReapterView<T> received a "
@@ -196,7 +194,7 @@
                 control._collectionChangedHandle.Dispose();
             }
 
-            control._collectionChangedHandle = new CollectionChangedHandle<View, T>(
+            control._collectionChangedHandle = new CollectionChangedHandle<View>(
                 control.Children,
                 newValue,
                 control.ViewFor,

--- a/src/Forms/XLabs.Forms/Controls/TemplateSelector.cs
+++ b/src/Forms/XLabs.Forms/Controls/TemplateSelector.cs
@@ -34,6 +34,17 @@ namespace XLabs.Forms.Controls
             {
                 Templates = new DataTemplateCollection();
             }
+
+            /// <summary>
+            /// Adds a DataTemplate to the selectory
+            /// </summary>
+            /// <param name="template">The template to add</param>
+            /// <param name="type">The Type this DataTemplate applies to</param>
+            public void Add(DataTemplate template, Type type = null)
+            {
+                Templates.Add(new DataTemplateWrapper() { WrappedTemplate = template, Type = type });
+            }
+
             /// <summary>
             ///  Clears the cache when the set of templates change
             /// </summary>
@@ -191,7 +202,7 @@ namespace XLabs.Forms.Controls
         {
             bool IsDefault { get; set; }
             DataTemplate WrappedTemplate { get; set; }
-            Type Type { get; }
+            Type Type { get; set; }
         }
         /// <summary>
         /// Wrapper for a DataTemplate.
@@ -200,10 +211,25 @@ namespace XLabs.Forms.Controls
         /// </summary>
         /// <typeparam name="T">The object type that this DataTemplateWrapper matches</typeparam>
         [ContentProperty("WrappedTemplate")]
-        public class DataTemplateWrapper<T> : BindableObject, IDataTemplateWrapper
+        public class DataTemplateWrapper : BindableObject, IDataTemplateWrapper
         {
-            public static readonly BindableProperty WrappedTemplateProperty = BindableProperty.Create<DataTemplateWrapper<T>, DataTemplate>(x => x.WrappedTemplate, null);
-            public static readonly BindableProperty IsDefaultProperty = BindableProperty.Create<DataTemplateWrapper<T>, bool>(x => x.IsDefault, false);
+            public static readonly BindableProperty WrappedTemplateProperty = BindableProperty.Create<DataTemplateWrapper, DataTemplate>(x => x.WrappedTemplate, null);
+            public static readonly BindableProperty IsDefaultProperty = BindableProperty.Create<DataTemplateWrapper, bool>(x => x.IsDefault, false);
+
+	        /// <summary>
+	        /// Default constructor
+	        /// </summary>
+	        public DataTemplateWrapper()
+	        {
+	        }
+	        /// <summary>
+	        /// Constructor that takes in a type.
+	        /// </summary>
+	        /// <param name="type">The type of object this DataTemplate applies to</param>
+	        public DataTemplateWrapper(Type type)
+	        {
+	            Type = type;
+	        }
 
             public bool IsDefault
             {
@@ -216,10 +242,7 @@ namespace XLabs.Forms.Controls
                 set { SetValue(WrappedTemplateProperty, value); }
             }
 
-            public Type Type
-            {
-                get { return typeof(T); }
-            }
+            public Type Type { get; set; }
         }
 
         /// <summary>


### PR DESCRIPTION
Removed generics from `RepeaterView`.

Why? `RepeaterView` is overly complex due to generics. It should use `IEnumerable` instead of `IEnumerable<T>`. It makes it vastly easier to use without generics. Likewise, `DataTemplateWrapper` and `CollectionChangedHandle` should not be generic for the same reason.

The View shouldn't even know about the View or the DataModel. Any list should bind just fine.

Also, confusion comes into play when you have the following design in MVVM.

```csharp
interface IAB {}
class A : IAB {}
class B : A : IAB {}
List<A>
List<B>
List<IAB>
class AViewModel {}
class BViewModel {}
List<AViewModel>
List<BViewModel>
```

Now which do you want use. Well, you might you use any of them and switch back and forth while coding until you get the right one. However, every time you switch your list, you shouldn't have to recode your View. With a generic `RepeaterView`, you would have to recode your View to switch your list type. With these changes, any of the above list types will work.

Also, there needed to be an example of using a `TemplateSelector` with `RepeaterView`. 

Also, the `RepeaterView.TemplateSelector` name is ambigous. Is it the template for the `RepeaterView` or the items? So I renamed it to `RepeaterView.ItemTemplateSelector`, which is more accurate.