### PR TITLE
Fixed bug where email sheet was not presented if top controller was modal

### DIFF
--- a/src/Platform/XLabs.Platform.iOS/Services/Email/EmailService.cs
+++ b/src/Platform/XLabs.Platform.iOS/Services/Email/EmailService.cs
@@ -61,7 +61,12 @@ namespace XLabs.Platform.Services.Email
 				}
 			}
 
-			UIApplication.SharedApplication.KeyWindow.RootViewController.PresentViewController(mailer, true, null);
+            UIViewController vc = UIApplication.SharedApplication.KeyWindow.RootViewController;
+            while(vc.PresentedViewController != null) 
+            {
+                vc = vc.PresentedViewController;
+            }
+            vc.PresentViewController(mailer, true, null);
 		}
 
 		/// <summary>


### PR DESCRIPTION
The window root view controller will not always be the one that iOS
considers the topmost. If a view controller is presented modally on top
of the root view, this modal should be used for presenting the email
sheet.

The code travels upwards through “PresentedViewController” until the
topmost is reached.