### PR TITLE
Fix Issue #860

### DIFF
--- a/src/Platform/XLabs.Platform.iOS/Services/Media/SoundService.cs
+++ b/src/Platform/XLabs.Platform.iOS/Services/Media/SoundService.cs
@@ -160,7 +160,7 @@ namespace XLabs.Platform.Services.Media
             return Task.Run<SoundFile>(
                 async () =>
                     {
-                        if (this.player == null || string.Compare(filename, CurrentFile.Filename) > 0)
+                        if (this.player == null || string.Compare(filename, CurrentFile.Filename) != 0)
                         {
                             await SetMediaAsync(filename);
                         }


### PR DESCRIPTION
Use `Compare() != 0` instead of `> 0` because `Compare()` might return -1 depending on the inputs.