### PR TITLE
Changed linebreakmode on ImageButton on iOS to match Android behavior

### DIFF
--- a/src/Forms/XLabs.Forms.iOS/Controls/ImageButton/ImageButtonRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/ImageButton/ImageButtonRenderer.cs
@@ -52,6 +52,9 @@ namespace XLabs.Forms.Controls
             var targetButton = Control;
             if (imageButton != null && targetButton != null && imageButton.Source != null)
             {
+                // Matches Android ImageButton behavior
+                targetButton.LineBreakMode = UIKit.UILineBreakMode.WordWrap;
+
                 var width = this.GetWidth(imageButton.ImageWidthRequest);
                 var height = this.GetHeight(imageButton.ImageHeightRequest);
 


### PR DESCRIPTION
The ImageButton Label behaviour is inconsistent between iOS and Android. The Android button wraps while the iOS button truncates. Until this is exposed as a property, I suggest changing the iOS behaviour to match Android.