### PR TITLE
Added TintColor support to ImageButton

### DIFF
--- a/src/Forms/XLabs.Forms.Droid/Controls/ImageButton/ImageButtonRenderer.cs
+++ b/src/Forms/XLabs.Forms.Droid/Controls/ImageButton/ImageButtonRenderer.cs
@@ -50,7 +50,9 @@ namespace XLabs.Forms.Controls
                 targetButton.Typeface = Element.Font.ToExtendedTypeface(Context);
             }
 
-            if (this.Element != null && this.ImageButton.Source != null )
+            if (this.Element != null && 
+                (this.ImageButton.Source != null ||
+                this.ImageButton.DisabledSource != null))
             {
                 await this.SetImageSourceAsync(targetButton, this.ImageButton);
             }
@@ -68,12 +70,18 @@ namespace XLabs.Forms.Controls
             const int Padding = 10;
             var source = model.IsEnabled ? model.Source : model.DisabledSource ?? model.Source;
 
-
             using (var bitmap = await this.GetBitmapAsync(source))
             {
                 if (bitmap != null)
                 {
-                    Drawable drawable = new BitmapDrawable(bitmap);
+                    var drawable = new BitmapDrawable(bitmap);
+                    var tintColor = model.IsEnabled ? model.ImageTintColor : model.DisabledImageTintColor;
+                    if (tintColor != Xamarin.Forms.Color.Transparent)
+                    {
+                        drawable.SetTint(tintColor.ToAndroid());
+                        drawable.SetTintMode(PorterDuff.Mode.SrcIn);
+                    }
+
                     var scaledDrawable = GetScaleDrawable(drawable, GetWidth(model.ImageWidthRequest),
                         GetHeight(model.ImageHeightRequest));
 
@@ -129,7 +137,11 @@ namespace XLabs.Forms.Controls
         {
             base.OnElementPropertyChanged(sender, e);
 
-            if (e.PropertyName == ImageButton.SourceProperty.PropertyName || e.PropertyName == ImageButton.DisabledSourceProperty.PropertyName || e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+            if (e.PropertyName == ImageButton.SourceProperty.PropertyName || 
+                e.PropertyName == ImageButton.DisabledSourceProperty.PropertyName || 
+                e.PropertyName == VisualElement.IsEnabledProperty.PropertyName ||
+                e.PropertyName == ImageButton.ImageTintColorProperty.PropertyName ||
+                e.PropertyName == ImageButton.DisabledImageTintColorProperty.PropertyName)
             {
                 await SetImageSourceAsync(this.Control, this.ImageButton);
             }

--- a/src/Forms/XLabs.Forms/Controls/ImageButton.cs
+++ b/src/Forms/XLabs.Forms/Controls/ImageButton.cs
@@ -54,6 +54,20 @@ namespace XLabs.Forms.Controls
                 p => p.Orientation, ImageOrientation.ImageToLeft);
 
         /// <summary>
+        /// Backing field for the tint color property.
+        /// </summary>
+        public static readonly BindableProperty ImageTintColorProperty =
+            BindableProperty.Create<ImageButton, Color>(
+                p => p.ImageTintColor, Color.Transparent);
+
+        /// <summary>
+        /// Backing field for the disbaled tint color property.
+        /// </summary>
+        public static readonly BindableProperty DisabledImageTintColorProperty =
+            BindableProperty.Create<ImageButton, Color>(
+                p => p.DisabledImageTintColor, Color.Transparent);
+
+        /// <summary>
         /// Gets or sets the ImageSource to use with the control.
         /// </summary>
         /// <value>
@@ -115,6 +129,30 @@ namespace XLabs.Forms.Controls
         {
             get { return (int)GetValue(ImageWidthRequestProperty); }
             set { SetValue(ImageWidthRequestProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the tint color of the image 
+        /// </summary>
+        /// <value>
+        /// The ImageTintColor property gets/sets the value of the backing field, ImageTintColorProperty.
+        /// </value> 
+        public Color ImageTintColor
+        {
+            get { return (Color)GetValue(ImageTintColorProperty); }
+            set { SetValue(ImageTintColorProperty, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the tint color of the image when the button is disabled
+        /// </summary>
+        /// <value>
+        /// The DisabledImageTintColor property gets/sets the value of the backing field, DisabledImageTintColorProperty.
+        /// </value> 
+        public Color DisabledImageTintColor
+        {
+            get { return (Color)GetValue(DisabledImageTintColorProperty); }
+            set { SetValue(DisabledImageTintColorProperty, value); }
         }
     }
 }


### PR DESCRIPTION
Images from sites such as Iconfinder are black & white only. The ImageTintColor property allows you to add a black & white image and change it's color simply by supplying a ImageTintColor. This also works for Disabled states (no need for a DisabledImageSource)

PS: There's an inconsistency in Xamarin.Forms where the disabled iOS button gets greyed out but this does not happen on Android - I have not fixed this.