### PR TITLE
Fixed LongPress gesture

### DIFF
--- a/src/Forms/XLabs.Forms.iOS/Controls/GesturesContentView/GesturesContentViewRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/GesturesContentView/GesturesContentViewRenderer.cs
@@ -64,7 +64,7 @@ namespace XLabs.Forms.Controls
                     if (x.State == UIGestureRecognizerState.Ended)
                     {
                         var viewpoint = x.LocationInView(this);
-                        this.Element.ProcessGesture(new GestureResult { GestureType = GestureType.DoubleTap, Direction = Directionality.None, Origin = viewpoint.ToPoint() });                        
+                        this.Element.ProcessGesture(new GestureResult { GestureType = GestureType.LongPress, Direction = Directionality.None, Origin = viewpoint.ToPoint() });                        
                     }
                 }));
             // Swipe


### PR DESCRIPTION
LongPress gesture will be process a DoubleTap gesture before on GesturesContentView. The change in this pull request fixed the problem.