### PR TITLE
Fixed issue #668

### DIFF
--- a/src/Forms/XLabs.Forms/Mvvm/ViewFactory.cs
+++ b/src/Forms/XLabs.Forms/Mvvm/ViewFactory.cs
@@ -82,9 +82,10 @@ namespace XLabs.Forms.Mvvm
 		/// </summary>
 		/// <param name="viewModelType">Type of the view model.</param>
 		/// <param name="initialiser">The initialiser.</param>
+		/// <param name="args">The arguments.</param>
 		/// <returns>System.Object.</returns>
 		/// <exception cref="System.InvalidOperationException">Unknown View for ViewModel</exception>
-		public static object CreatePage(Type viewModelType, Action<object, object> initialiser = null)
+		public static object CreatePage(Type viewModelType, Action<object, object> initialiser = null, params object[] args)
 		{
 			Type viewType;
 
@@ -111,7 +112,7 @@ namespace XLabs.Forms.Mvvm
 			{
 				viewModel = (Resolver.Resolve(viewModelType) ?? Activator.CreateInstance(viewModelType)) as IViewModel;
 
-				page = Activator.CreateInstance(viewType);
+				page = Activator.CreateInstance(viewType, args);
 
 				if (EnableCache)
 				{
@@ -148,9 +149,10 @@ namespace XLabs.Forms.Mvvm
 		/// <typeparam name="TViewModel">The type of the view model.</typeparam>
 		/// <typeparam name="TPage">The type of the t page.</typeparam>
 		/// <param name="initialiser">The create action.</param>
+		/// <param name="args">The arguments.</param>
 		/// <returns>Page for the ViewModel.</returns>
 		/// <exception cref="System.InvalidOperationException">Unknown View for ViewModel.</exception>
-		public static object CreatePage<TViewModel, TPage>(Action<TViewModel, TPage> initialiser = null)
+		public static object CreatePage<TViewModel, TPage>(Action<TViewModel, TPage> initialiser = null, params object[] args)
 			where TViewModel : class, IViewModel
 		{
 			Action<object, object> i = (o1, o2) =>
@@ -161,7 +163,7 @@ namespace XLabs.Forms.Mvvm
 				}
 			};
 
-			return CreatePage(typeof (TViewModel), i);
+			return CreatePage(typeof (TViewModel), i, args);
 		}
 	}
 }

--- a/src/Forms/XLabs.Forms/Services/NavigationService.cs
+++ b/src/Forms/XLabs.Forms/Services/NavigationService.cs
@@ -3,8 +3,8 @@
 // Author           : Shawn Anderson
 // Created          : 12-29-2014
 //
-// Last Modified By : Shawn Anderson
-// Last Modified On : 12-29-2014
+// Last Modified By : AngryPowman
+// Last Modified On : 08-04-2015
 // ***********************************************************************
 // <copyright file="NavigationService.cs" company="">
 //     Copyright (c) 2014 . All rights reserved.
@@ -21,7 +21,6 @@ namespace XLabs.Forms.Services
 	using System;
 	using System.Collections.Generic;
 	using System.Reflection;
-
 	using XLabs.Platform.Services;
 
 	/// <summary>
@@ -73,10 +72,10 @@ namespace XLabs.Forms.Services
 		/// Navigates to.
 		/// </summary>
 		/// <param name="pageKey">The page key.</param>
-		/// <param name="parameter">The parameter.</param>
 		/// <param name="animated">if set to <c>true</c> [animated].</param>
+		/// <param name="args">The arguments.</param>
 		/// <exception cref="System.ArgumentException">That pagekey is not registered;pageKey</exception>
-		public void NavigateTo(string pageKey, object parameter = null, bool animated = true)
+		public void NavigateTo(string pageKey, bool animated = true, params object[] args)
 		{
 			if (!this._pageLookup.ContainsKey(pageKey))
 			{
@@ -85,17 +84,17 @@ namespace XLabs.Forms.Services
 
 			var pageType = this._pageLookup[pageKey];
 
-			this.NavigateTo(pageType, parameter, animated);
+			this.NavigateTo(pageType, animated, args);
 		}
 
 		/// <summary>
 		/// Navigates to.
 		/// </summary>
 		/// <param name="pageType">Type of the page.</param>
-		/// <param name="parameter">The parameter.</param>
 		/// <param name="animated">if set to <c>true</c> [animated].</param>
+		/// <param name="args">The arguments.</param>
 		/// <exception cref="System.ArgumentException">Argument must be derived from type Xamarin.Forms.Page;pageType</exception>
-		public void NavigateTo(Type pageType, object parameter = null, bool animated = true)
+		public void NavigateTo(Type pageType, bool animated = true, params object[] args)
 		{
 			if (_navigation == null)
 			{
@@ -109,11 +108,11 @@ namespace XLabs.Forms.Services
 
 			if (pInfo.IsAssignableFrom(xlvm) || pInfo.IsSubclassOf(typeof(ViewModel)))
 			{
-				page = ViewFactory.CreatePage(pageType);
+				page = ViewFactory.CreatePage(pageType, null, args);
 			}
 			else if (pInfo.IsAssignableFrom(xfPage) || pInfo.IsSubclassOf(typeof(Xamarin.Forms.Page)))
 			{
-				page = Activator.CreateInstance(pageType);
+				page = Activator.CreateInstance(pageType, args);
 			}
 			else
 			{
@@ -127,12 +126,12 @@ namespace XLabs.Forms.Services
 		/// Navigates to.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
-		/// <param name="parameter">The parameter.</param>
 		/// <param name="animated">if set to <c>true</c> [animated].</param>
+		/// <param name="args">The arguments.</param>
 		/// <exception cref="System.ArgumentException">Page Type must be based on Xamarin.Forms.Page</exception>
-		public void NavigateTo<T>(object parameter = null, bool animated = true) where T : class
-		{		
-			NavigateTo(typeof(T), parameter, animated);
+		public void NavigateTo<T>(bool animated = true, params object[] args) where T : class
+		{
+			NavigateTo(typeof(T), animated, args);
 		}
 
 		/// <summary>

--- a/src/Platform/XLabs.Platform/Services/INavigationService.cs
+++ b/src/Platform/XLabs.Platform/Services/INavigationService.cs
@@ -18,26 +18,26 @@
 		/// Navigates to.
 		/// </summary>
 		/// <param name="pageKey">The page key.</param>
-		/// <param name="parameter">The parameter.</param>
+		/// <param name="args">The arguments.</param>
 		/// <param name="animated">if set to <c>true</c> [animated].</param>
-		void NavigateTo(string pageKey, object parameter = null, bool animated = true);
+		void NavigateTo(string pageKey, bool animated = true, params object[] args);
 
 		/// <summary>
 		/// Navigates to.
 		/// </summary>
 		/// <param name="pageType">Type of the page.</param>
-		/// <param name="parameter">The parameter.</param>
+		/// <param name="args">The arguments.</param>
 		/// <param name="animated">if set to <c>true</c> [animated].</param>
-		void NavigateTo(Type pageType, object parameter = null, bool animated = true);
+		void NavigateTo(Type pageType, bool animated = true, params object[] args);
 
 
 		/// <summary>
 		/// Navigates to.
 		/// </summary>
 		/// <typeparam name="T"></typeparam>
-		/// <param name="parameter">The parameter.</param>
+		/// <param name="args">The arguments.</param>
 		/// <param name="animated">if set to <c>true</c> [animated].</param>
-		void NavigateTo<T>(object parameter = null, bool animated = true) where T : class;
+		void NavigateTo<T>(bool animated = true, params object[] args) where T : class;
 
 		/// <summary>
 		/// Goes back.


### PR DESCRIPTION
This problem have led ```NavigationService.NavigateTo()``` unable to take arguments for constructing view class.

------

Now you can do that like so:
```csharp
NavigationService.NavigateTo<YourViewModel>(true, arguments)
```

The definitions as follows :

        void NavigateTo<T>(bool animated = true, params object[] args) where T : class;
        void NavigateTo(string pageKey, bool animated = true, params object[] args);
        void NavigateTo(Type pageType, bool animated = true, params object[] args);

The last parameter args on these methods is a list that can put some parameters for constructing your view class.

------
**NOTICE:**
Function definitions of `NavigateTo()` have been changed, code might contain some compilation errors.

------
See also: https://github.com/XLabs/Xamarin-Forms-Labs/issues/668