### PR TITLE
During calculation of size, only take visible children into account

### DIFF
--- a/src/Forms/XLabs.Forms/Controls/WrapLayout.cs
+++ b/src/Forms/XLabs.Forms/Controls/WrapLayout.cs
@@ -105,7 +105,7 @@ namespace XLabs.Forms.Controls
             double minHeight = 0;
             double heightUsed = 0;
 
-            foreach (var size in Children.Select(item => item.GetSizeRequest(widthConstraint, heightConstraint)))
+            foreach (var size in Children.Where(c => c.IsVisible).Select(item => item.GetSizeRequest(widthConstraint, heightConstraint)))
             {
                 width = Math.Max(width, size.Request.Width);
 
@@ -153,7 +153,7 @@ namespace XLabs.Forms.Controls
             double minHeight = 0;
             double widthUsed = 0;
 
-            foreach (var item in Children)
+            foreach (var item in Children.Where(c => c.IsVisible))
             {
                 var size = item.GetSizeRequest(widthConstraint, heightConstraint);
 


### PR DESCRIPTION
The size of the WrapLayout was calculated using both visible and
non-visible children. The non-visible children are not shown in any
case and the result is an empty space.