### PR TITLE
Feature/fix build script

### DIFF
--- a/.nuget/Definition/Build.ps1
+++ b/.nuget/Definition/Build.ps1
@@ -159,6 +159,9 @@ try
 
     ## Move NuGet package to Package Release folder"
     Write-Host "Move package to ..\Packages folder..." -ForegroundColor Yellow
+    if(!Test-Path($pathToNuGetPackageOutput)) {
+        New-Item -Path $pathToNuGetPackageOutput -ItemType Directory -Force | Out-Null
+    } 
     Move-Item "*.nupkg" -Destination $pathToNuGetPackageOutput -Force
     
     ## Cleanup after ourselves

--- a/.nuget/Definition/Build.ps1
+++ b/.nuget/Definition/Build.ps1
@@ -159,7 +159,7 @@ try
 
     ## Move NuGet package to Package Release folder"
     Write-Host "Move package to ..\Packages folder..." -ForegroundColor Yellow
-    if(!Test-Path($pathToNuGetPackageOutput)) {
+    if(!(Test-Path($pathToNuGetPackageOutput))) {
         New-Item -Path $pathToNuGetPackageOutput -ItemType Directory -Force | Out-Null
     } 
     Move-Item "*.nupkg" -Destination $pathToNuGetPackageOutput -Force


### PR DESCRIPTION
The build script for NuGet packages had a bug: If ..\Packages directory did not exist packages would be copied to a file named Packages instead of a new directory.