### PR TITLE
Prevent null pointer exception

### DIFF
--- a/src/Forms/XLabs.Forms.Droid/Controls/WebImage/WebImageRenderer.cs
+++ b/src/Forms/XLabs.Forms.Droid/Controls/WebImage/WebImageRenderer.cs
@@ -43,7 +43,7 @@ namespace XLabs.Forms.Controls
 			var networkStatus = Reachability.InternetConnectionStatus();
 			var isReachable = networkStatus != NetworkStatus.NotReachable;
 
-			if (isReachable)
+			if (isReachable && !string.IsNullOrEmpty(WebImage.ImageUrl))
 			{
 				image = GetImageFromWeb(WebImage.ImageUrl);
 			}


### PR DESCRIPTION
Prevent null pointer exception if ImageUrl is not specified when call
webClient.DownloadData