### PR TITLE
fix: ElementOnPropertyChanged can remain hooked after detaching renderer

### DIFF
--- a/src/Forms/XLabs.Forms.Droid/Controls/RadioButton/RadioButtonRenderer.cs
+++ b/src/Forms/XLabs.Forms.Droid/Controls/RadioButton/RadioButtonRenderer.cs
@@ -16,19 +16,14 @@ namespace XLabs.Forms.Controls
 	/// Class RadioButtonRenderer.
 	/// </summary>
 	public class RadioButtonRenderer : ViewRenderer<CustomRadioButton, RadioButton>
-    {
-		/// <summary>
+	{
+	    /// <summary>
 		/// Called when [element changed].
 		/// </summary>
 		/// <param name="e">The e.</param>
 		protected override void OnElementChanged(ElementChangedEventArgs<CustomRadioButton> e)
         {
             base.OnElementChanged(e);
-
-            if (e.OldElement != null)
-            {
-                e.OldElement.PropertyChanged -= ElementOnPropertyChanged;
-            }
 
             if (Control == null)
             {
@@ -53,8 +48,6 @@ namespace XLabs.Forms.Controls
             {
                 Control.Typeface = TrySetFont(e.NewElement.FontName);
             }
-
-            Element.PropertyChanged += ElementOnPropertyChanged;
         }
 
         private void radButton_CheckedChange(object sender, CompoundButton.CheckedChangeEventArgs e)
@@ -62,8 +55,10 @@ namespace XLabs.Forms.Controls
             Element.Checked = e.IsChecked;
         }
 
-        private void ElementOnPropertyChanged(object sender, PropertyChangedEventArgs e)
+        protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
+            base.OnElementPropertyChanged(sender, e);
+
             switch (e.PropertyName)
             {
                 case "Checked":


### PR DESCRIPTION
OnElementChanged does not (always) being called when the renderer is being detached. So we should have implemented Dispose and unhook ElementOnPropertyChanged there also.
However after some testing it seems overriding OnElementPropertyChanged is working fine also and this results in a cleaner and smaller code. If it still does not work well, I'm going to implement the first way.