### PR TITLE
[Android] support default TextColor...

### DIFF
--- a/src/Forms/XLabs.Forms.Droid/Controls/CheckBox/CheckBoxRenderer.cs
+++ b/src/Forms/XLabs.Forms.Droid/Controls/CheckBox/CheckBoxRenderer.cs
@@ -1,3 +1,4 @@
+using Android.Content.Res;
 using Xamarin.Forms;
 
 using XLabs.Forms.Controls;
@@ -18,7 +19,9 @@ namespace XLabs.Forms.Controls
 	/// </summary>
 	public class CheckBoxRenderer : ViewRenderer<CheckBox, Android.Widget.CheckBox>
 	{
-		/// <summary>
+        private ColorStateList defaultTextColor;
+        
+        /// <summary>
 		/// Called when [element changed].
 		/// </summary>
 		/// <param name="e">The e.</param>
@@ -31,12 +34,13 @@ namespace XLabs.Forms.Controls
 				var checkBox = new Android.Widget.CheckBox(this.Context);
 				checkBox.CheckedChange += CheckBoxCheckedChange;
 
+			    defaultTextColor = checkBox.TextColors;
 				this.SetNativeControl(checkBox);
 			}
 
 			Control.Text = e.NewElement.Text;
 			Control.Checked = e.NewElement.Checked;
-			Control.SetTextColor(e.NewElement.TextColor.ToAndroid());
+            UpdateTextColor();
 
 			if (e.NewElement.FontSize > 0)
 			{
@@ -65,7 +69,7 @@ namespace XLabs.Forms.Controls
 					Control.Checked = Element.Checked;
 					break;
 				case "TextColor":
-					Control.SetTextColor(Element.TextColor.ToAndroid());
+			        UpdateTextColor();
 					break;
 				case "FontName":
 					if (!string.IsNullOrEmpty(Element.FontName))
@@ -127,5 +131,19 @@ namespace XLabs.Forms.Controls
 				}
 			}
 		}
+
+        /// <summary>
+        /// Updates the color of the text
+        /// </summary>
+        private void UpdateTextColor()
+        {
+            if (Control == null || Element == null)
+                return;
+
+            if (Element.TextColor == Xamarin.Forms.Color.Default)
+                Control.SetTextColor(defaultTextColor);
+            else
+                Control.SetTextColor(Element.TextColor.ToAndroid());
+        }
 	}
 }

--- a/src/Forms/XLabs.Forms.Droid/Controls/ExtendedButton/ExtendedButtonRenderer.cs
+++ b/src/Forms/XLabs.Forms.Droid/Controls/ExtendedButton/ExtendedButtonRenderer.cs
@@ -22,7 +22,8 @@ namespace XLabs.Forms.Controls
 		protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
         {
             base.OnElementChanged(e);
-            SetAlignment();
+	        UpdateAlignment();
+	        UpdateFont();
         }
 
 		/// <summary>
@@ -32,22 +33,31 @@ namespace XLabs.Forms.Controls
 		/// <param name="e">The <see cref="PropertyChangedEventArgs"/> instance containing the event data.</param>
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            switch (e.PropertyName)
+		    if (e.PropertyName == ExtendedButton.VerticalContentAlignmentProperty.PropertyName ||
+		        e.PropertyName == ExtendedButton.HorizontalContentAlignmentProperty.PropertyName)
+		    {
+		        UpdateAlignment();
+		    }
+            else if (e.PropertyName == Button.FontProperty.PropertyName)
             {
-                case "VerticalContentAlignment":
-                case "HorizontalContentAlignment":
-                    SetAlignment();
-                    break;
-                default:
-                    base.OnElementPropertyChanged(sender, e);
-                    break;
+                UpdateFont();
             }
+             
+            base.OnElementPropertyChanged(sender, e);
         }
+
+        /// <summary>
+        /// Updates the font
+        /// </summary>
+	    private void UpdateFont()
+	    {
+            Control.Typeface = Element.Font.ToExtendedTypeface(Context);
+	    }
 
 		/// <summary>
 		/// Sets the alignment.
 		/// </summary>
-		private void SetAlignment()
+		private void UpdateAlignment()
         {
             var element = this.Element as ExtendedButton;
 

--- a/src/Forms/XLabs.Forms.Droid/Controls/IconButton/IconButtonRenderer.cs
+++ b/src/Forms/XLabs.Forms.Droid/Controls/IconButton/IconButtonRenderer.cs
@@ -144,6 +144,14 @@ namespace XLabs.Forms.Controls
             return computedText;
         }
 
+        private Android.Graphics.Color GetSpanColor(Xamarin.Forms.Color color)
+        {
+            if (color == Xamarin.Forms.Color.Default)
+                return new Android.Graphics.Color(Control.TextColors.DefaultColor);
+
+            return color.ToAndroid();
+        }
+
         /// <summary>
         /// Build the spannable according to the computed text, meaning set the right font, color and size to the text and icon char index
         /// </summary>
@@ -156,7 +164,7 @@ namespace XLabs.Forms.Controls
             if (!string.IsNullOrEmpty(iconButton.Icon))
             {
                 //set icon
-                span.SetSpan(new CustomTypefaceSpan("fontawesome", iconFont, iconButton.IconColor.ToAndroid()),
+                span.SetSpan(new CustomTypefaceSpan("fontawesome", iconFont, GetSpanColor(iconButton.IconColor)),
                     computedString.IndexOf(iconButton.Icon),
                     computedString.IndexOf(iconButton.Icon) + iconButton.Icon.Length,
                     SpanTypes.ExclusiveExclusive);
@@ -171,7 +179,7 @@ namespace XLabs.Forms.Controls
             //if there is text
             if (!string.IsNullOrEmpty(iconButton.Text))
             {
-                span.SetSpan(new CustomTypefaceSpan("", textFont, iconButton.TextColor.ToAndroid()),
+                span.SetSpan(new CustomTypefaceSpan("", textFont, GetSpanColor(iconButton.TextColor)),
                      textStartIndex,
                      textStopIndex,
                      SpanTypes.ExclusiveExclusive);

--- a/src/Forms/XLabs.Forms.Droid/Controls/RadioButton/RadioButtonRenderer.cs
+++ b/src/Forms/XLabs.Forms.Droid/Controls/RadioButton/RadioButtonRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using Android.Content.Res;
 using Android.Graphics;
 using Android.Widget;
 using Xamarin.Forms;
@@ -17,6 +18,8 @@ namespace XLabs.Forms.Controls
 	/// </summary>
 	public class RadioButtonRenderer : ViewRenderer<CustomRadioButton, RadioButton>
 	{
+	    private ColorStateList defaultTextColor;
+
 	    /// <summary>
 		/// Called when [element changed].
 		/// </summary>
@@ -28,6 +31,7 @@ namespace XLabs.Forms.Controls
             if (Control == null)
             {
                 var radButton = new RadioButton(Context);
+                defaultTextColor = radButton.TextColors;
 
                 radButton.CheckedChange += radButton_CheckedChange;
 
@@ -37,7 +41,7 @@ namespace XLabs.Forms.Controls
             Control.Text = e.NewElement.Text;
             //Control.TextSize = 14;
             Control.Checked = e.NewElement.Checked;
-            Control.SetTextColor(e.NewElement.TextColor.ToAndroid());
+	        UpdateTextColor();
 
             if (e.NewElement.FontSize > 0)
             {
@@ -68,7 +72,7 @@ namespace XLabs.Forms.Controls
                     Control.Text = Element.Text;
                     break;
                 case "TextColor":
-                    Control.SetTextColor(Element.TextColor.ToAndroid());
+                    UpdateTextColor();
                     break;
                 case "FontName":
                     if (!string.IsNullOrEmpty(Element.FontName))
@@ -116,6 +120,20 @@ namespace XLabs.Forms.Controls
                     return Typeface.Default;
                 }
             }
+        }
+
+        /// <summary>
+        /// Updates the color of the text
+        /// </summary>
+	    private void UpdateTextColor()
+	    {
+	        if (Control == null || Element == null)
+	            return;
+
+	        if (Element.TextColor == Xamarin.Forms.Color.Default)
+                Control.SetTextColor(defaultTextColor);
+            else
+                Control.SetTextColor(Element.TextColor.ToAndroid());
         }
     }
 }

--- a/src/Forms/XLabs.Forms/Controls/CheckBox.cs
+++ b/src/Forms/XLabs.Forms/Controls/CheckBox.cs
@@ -43,7 +43,7 @@ namespace XLabs.Forms.Controls
 		/// <remarks/>
 		public static readonly BindableProperty TextColorProperty =
 			BindableProperty.Create<CheckBox, Color>(
-				p => p.TextColor, Color.Black);
+				p => p.TextColor, Color.Default);
 
 		/// <summary>
 		/// The font size property

--- a/src/Forms/XLabs.Forms/Controls/IconButton.cs
+++ b/src/Forms/XLabs.Forms/Controls/IconButton.cs
@@ -105,7 +105,7 @@ namespace XLabs.Forms.Controls
 		/// </summary>
 		public static readonly BindableProperty IconColorProperty =
 			BindableProperty.Create<IconButton, Color>(
-				p => p.IconColor, default(Color));
+				p => p.IconColor, Color.Default);
 
 		/// <summary>
 		/// Gets or sets the icon's color

--- a/src/Forms/XLabs.Forms/Controls/RadioButton/CustomRadioButton.cs
+++ b/src/Forms/XLabs.Forms/Controls/RadioButton/CustomRadioButton.cs
@@ -27,7 +27,7 @@ namespace XLabs.Forms.Controls
         /// </summary>
         public static readonly BindableProperty TextColorProperty =
             BindableProperty.Create<CustomRadioButton, Color>(
-                p => p.TextColor, Color.Black);
+                p => p.TextColor, Color.Default);
 
         /// <summary>
         /// The font size property


### PR DESCRIPTION
for CheckBox, CustomRadioButton and IconButton. The default value of TextColor (IconColor on IconButton) has been changed to Color.Default. This probably does not make any problems (previously you had to specifiy color explicitly), but it should be checked on iOS - I don't have access to such device.
Also added support of custom fonts to ExtendedButton (only renderer had to be changed).
