### PR TITLE
Add multiple attachments with Android

### DIFF
--- a/src/Platform/XLabs.Platform.Droid/Extensions/IntentExtensions.cs
+++ b/src/Platform/XLabs.Platform.Droid/Extensions/IntentExtensions.cs
@@ -5,35 +5,41 @@ namespace XLabs.Platform
 
 	using Android.Content;
 	using Android.Net;
+  using Android.OS;
 
 	/// <summary>
 	/// Class IntentExtensions.
 	/// </summary>
 	public static class IntentExtensions
-    {
+  {
 		/// <summary>
 		/// Adds the attachments.
 		/// </summary>
 		/// <param name="intent">The intent.</param>
 		/// <param name="attachments">The attachments.</param>
-        public static void AddAttachments(this Intent intent, IEnumerable<string> attachments)
-        {
-            if (attachments == null || !attachments.Any())
-            {
-                Android.Util.Log.Warn("Intent.AddAttachments", "No attachments to attach.");
-                return;
-            }
+    public static void AddAttachments(this Intent intent, IEnumerable<string> attachments)
+    {
+      if (attachments == null || !attachments.Any())
+      {
+        Android.Util.Log.Warn("Intent.AddAttachments", "No attachments to attach.");
+        return;
+      }
 
-			foreach (var attachment in attachments) {
-				var file = new Java.IO.File(attachment);
-				// File existence check
-				if (file.Exists()) {
-					intent.PutExtra(Intent.ExtraStream, Uri.FromFile(file));
-				}
-				else {
-                    Android.Util.Log.Warn("Intent.AddAttachments", "Unable to attach file '{0}', because it doesn't exist.", attachment);
-				}
-			}
+      IList<IParcelable> uris = new List<IParcelable>();
+      foreach (var attachment in attachments)
+      {
+        //convert from paths to Android friendly Parcelable Uri's
+        var file = new Java.IO.File(attachment);
+        if (file.Exists()) 
+        {
+          Uri u = Uri.FromFile(file);
+          uris.Add(u);
+        } else {
+            Android.Util.Log.Warn("Intent.AddAttachments", "Unable to attach file '{0}', because it doesn't exist.", attachment);
         }
+      }
+
+      intent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
     }
+  }
 }

--- a/src/Platform/XLabs.Platform.Droid/Services/Email/EmailService.cs
+++ b/src/Platform/XLabs.Platform.Droid/Services/Email/EmailService.cs
@@ -35,7 +35,7 @@ namespace XLabs.Platform.Services.Email
 		/// <param name="attachments">The attachments.</param>
 		public void ShowDraft(string subject, string body, bool html, string[] to, string[] cc, string[] bcc, IEnumerable<string> attachments = null)
 		{
-			var intent = new Intent(Intent.ActionSend);
+			var intent = new Intent(Intent.ActionSendMultiple);
 
 			intent.SetType(html ? "text/html" : "text/plain");
 			intent.PutExtra(Intent.ExtraEmail, to);
@@ -70,7 +70,7 @@ namespace XLabs.Platform.Services.Email
 		/// <param name="attachments">The attachments.</param>
 		public void ShowDraft(string subject, string body, bool html, string to, IEnumerable<string> attachments = null)
 		{
-			var intent = new Intent(Intent.ActionSend);
+			var intent = new Intent(Intent.ActionSendMultiple);
 			intent.SetType(html ? "text/html" : "text/plain");
 			intent.PutExtra(Intent.ExtraEmail, new string[]{ to });
 			intent.PutExtra(Intent.ExtraSubject, subject ?? string.Empty);


### PR DESCRIPTION
Change the Intent ExtraStream from a single Extra to a
ParcelableArrayListExtra, so we can send multiple attachments to the
Android mail clients. Otherwise only one attachment will be added.

The intent itself has been changed to ActionSendMultiple to achieve the
same goal.

fixes #1001

PS: the coding style has a lot of mixed usage of tabs and spaces. Contribution guidelines would be nice.