### PR TITLE
Update GridViewRenderer to appropriately handle change of ItemsSource

### DIFF
--- a/Samples/XLabs.Sample/Pages/Controls/GridViewPage.xaml
+++ b/Samples/XLabs.Sample/Pages/Controls/GridViewPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <mvvm:BaseView xmlns="http://xamarin.com/schemas/2014/forms"
 			   xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			   xmlns:mvvm="clr-namespace:XLabs.Forms.Mvvm;assembly=XLabs.Forms"
@@ -6,24 +6,36 @@
 			   x:Class="XLabs.Sample.Pages.Controls.GridViewPage"
 			   Title="GridView">
 	<mvvm:BaseView.Content>
-		<controls:GridView
-					x:Name="GrdView"
-					RowSpacing="5"
-					Padding="5"
-					ColumnSpacing = "5"
-					ItemWidth ="152"
-					ItemHeight = "200"
-					ItemsSource="{Binding Images}"
-				>
-			<controls:GridView.ItemTemplate>
-				<DataTemplate >
-					<ViewCell>
-						<ViewCell.View>
-							<Image Source="{Binding}" />
-						</ViewCell.View>
-					</ViewCell>
-				</DataTemplate>
-			</controls:GridView.ItemTemplate>
-		</controls:GridView>
+	<Grid>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="60" />
+			<RowDefinition Height="*" />
+		</Grid.RowDefinitions>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="33*" />
+			<ColumnDefinition Width="33*" />
+			<ColumnDefinition Width="33*" />
+		</Grid.ColumnDefinitions>
+			<Button Command="{Binding AddImagesCommand}" Text="Add Item" Grid.Column="0"/>
+			<Button Command="{Binding RemoveImagesCommand}" Text="Remove Item" Grid.Column="1"/>
+			<Button Command="{Binding ChangeImageSourceCommand}" Text="Switch item source" Grid.Column="2" />
+			<controls:GridView
+							x:Name="GrdView"
+							ItemWidth ="152"
+							ItemHeight = "200"
+							ItemsSource="{Binding Images}"
+							Grid.Row="1"
+							Grid.ColumnSpan="3">
+				<controls:GridView.ItemTemplate>
+					<DataTemplate >
+						<ViewCell>
+							<ViewCell.View>
+								<Image Source="{Binding}" />
+							</ViewCell.View>
+						</ViewCell>
+					</DataTemplate>
+				</controls:GridView.ItemTemplate>
+			</controls:GridView>
+		</Grid>
 	</mvvm:BaseView.Content>
 </mvvm:BaseView>

--- a/Samples/XLabs.Sample/ViewModel/MainViewModel.cs
+++ b/Samples/XLabs.Sample/ViewModel/MainViewModel.cs
@@ -51,7 +51,6 @@ namespace XLabs.Sample.ViewModel
                 {
                     Images.Add ("http://www.stockvault.net/data/2011/05/31/124348/small.jpg");
                 }
-                NotifyPropertyChanged(() => Images);
             });
         }
 

--- a/Samples/XLabs.Sample/ViewModel/MainViewModel.cs
+++ b/Samples/XLabs.Sample/ViewModel/MainViewModel.cs
@@ -1,4 +1,4 @@
-﻿namespace XLabs.Sample.ViewModel
+namespace XLabs.Sample.ViewModel
 {
     using System;
     using System.Collections.ObjectModel;
@@ -28,6 +28,9 @@
         public MainViewModel ()
         {
             SpeakCommand = new Command (() => Resolver.Resolve<ITextToSpeechService>().Speak(TextToSpeak));
+            AddImagesCommand = new Command(() => AddImages());
+            RemoveImagesCommand = new Command(() => RemoveImages());
+            ChangeImageSourceCommand = new Command(() => ChangeImageSource());
 
             Images = new ObservableCollection<string>();
             for (var i = 0; i < 10; i++)
@@ -38,6 +41,7 @@
             _device = Resolver.Resolve<IDevice>();
         }
 
+
         public Task AddImages()
         {
             return Task.Run(async () => 
@@ -47,7 +51,25 @@
                 {
                     Images.Add ("http://www.stockvault.net/data/2011/05/31/124348/small.jpg");
                 }
+                NotifyPropertyChanged(() => Images);
             });
+        }
+
+        public Task RemoveImages()
+        {
+            return Task.Run(async () => 
+            {
+                    for (var i = 0; i < 5; i++) 
+                {
+                    if(Images.Count > 0)
+                        Images.RemoveAt(0);
+                }
+            });
+        }
+
+        public void ChangeImageSource()
+        {
+            Images = new ObservableCollection<string>();
         }
 
         /// <summary>
@@ -172,6 +194,24 @@
         /// The speak command.
         /// </value>
         public Command SpeakCommand { get; private set; }
+
+        /// <summary>
+        /// Command to add images to the list
+        /// </summary>
+        /// <value>The add images command.</value>
+        public Command AddImagesCommand { get; private set; }
+
+        /// <summary>
+        /// Command to remove images from the list
+        /// </summary>
+        /// <value>The remove images command.</value>
+        public Command RemoveImagesCommand { get; private set; }
+
+        /// <summary>
+        /// Command to swap the image source to a new object
+        /// </summary>
+        /// <value>The change image source command.</value>
+        public Command ChangeImageSourceCommand { get; private set; }
         
         /// <summary>
         /// Gets the call command.

--- a/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
@@ -1,6 +1,7 @@
 using Xamarin.Forms;
 
 using XLabs.Forms.Controls;
+using System.Collections.Generic;
 
 [assembly: ExportRenderer (typeof(GridView), typeof(GridViewRenderer))]
 namespace XLabs.Forms.Controls
@@ -113,7 +114,7 @@ namespace XLabs.Forms.Controls
                         RowSpacing = this.Element.RowSpacing,
                         ColumnSpacing = this.Element.ColumnSpacing
                     };
-                    
+
                     Bind (e.NewElement);
 
                     collectionView.Source = this.DataSource;
@@ -123,7 +124,7 @@ namespace XLabs.Forms.Controls
                 }
             }
 
-        
+
         }
 
         /// <summary>
@@ -136,7 +137,7 @@ namespace XLabs.Forms.Controls
 
             oldElement.PropertyChanging -= this.ElementPropertyChanging;
             oldElement.PropertyChanged -= this.ElementPropertyChanged;
-                
+
             var itemsSource = oldElement.ItemsSource as INotifyCollectionChanged;
             if (itemsSource != null) 
             {
@@ -204,31 +205,33 @@ namespace XLabs.Forms.Controls
         /// <param name="e">The <see cref="NotifyCollectionChangedEventArgs"/> instance containing the event data.</param>
         private void DataCollectionChanged (object sender, NotifyCollectionChangedEventArgs e)
         {
-            try 
-            {
-            	if(this.Control == null) return;
+            InvokeOnMainThread (()=> {
+                try 
+                {
+                    if(this.Control == null) return;
 
-		// try to handle add or remove operations gracefully, just reload the whole collection for other changes
-                var indexes = new List<NSIndexPath>();
-                switch (e.Action) {
-                    case NotifyCollectionChangedAction.Add:
-                        for (int i = 0; i < e.NewItems.Count; i++) {
-                            indexes.Add(NSIndexPath.FromRowSection((nint)(e.NewStartingIndex + i),0));
-                        }
-                        this.Control.InsertItems(indexes.ToArray());
-                        break;
-                    case NotifyCollectionChangedAction.Remove:
-                        for (int i = 0; i< e.OldItems.Count; i++) {
-                            indexes.Add(NSIndexPath.FromRowSection((nint)(e.OldStartingIndex + i),0));
-                        }
-                        this.Control.DeleteItems(indexes.ToArray());
-                        break;
-                default:
-                        this.Control.ReloadData();
-                        break;
-                }
-            } 
-            catch { } // todo: determine why we are hiding a possible exception here
+                    // try to handle add or remove operations gracefully, just reload the whole collection for other changes
+                    var indexes = new List<NSIndexPath>();
+                    switch (e.Action) {
+                        case NotifyCollectionChangedAction.Add:
+                            for (int i = 0; i < e.NewItems.Count; i++) {
+                                indexes.Add(NSIndexPath.FromRowSection((nint)(e.NewStartingIndex + i),0));
+                            }
+                            this.Control.InsertItems(indexes.ToArray());
+                            break;
+                        case NotifyCollectionChangedAction.Remove:
+                            for (int i = 0; i< e.OldItems.Count; i++) {
+                                indexes.Add(NSIndexPath.FromRowSection((nint)(e.OldStartingIndex + i),0));
+                            }
+                            this.Control.DeleteItems(indexes.ToArray());
+                            break;
+                        default:
+                            this.Control.ReloadData();
+                            break;
+                    }
+                } 
+                catch { } // todo: determine why we are hiding a possible exception here
+            });
         }
 
         /// <summary>
@@ -243,11 +246,11 @@ namespace XLabs.Forms.Controls
             }
         }
 
-		/// <summary>
-		/// Releases unmanaged and - optionally - managed resources.
-		/// </summary>
-		/// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
-		protected override void Dispose (bool disposing)
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        /// <param name="disposing"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
+        protected override void Dispose (bool disposing)
         {
             base.Dispose (disposing);
             if (disposing && _dataSource != null)

--- a/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
@@ -175,7 +175,7 @@ namespace XLabs.Forms.Controls
                 if (newItemsSource != null) 
                 {
                     newItemsSource.CollectionChanged += DataCollectionChanged;
-                    DataCollectionChanged(null,null);
+                    this.Control.ReloadData();
                 }
             }
         }
@@ -206,7 +206,27 @@ namespace XLabs.Forms.Controls
         {
             try 
             {
-                if(this.Control != null) this.Control.ReloadData();
+            	if(this.Control == null) return;
+
+		// try to handle add or remove operations gracefully, just reload the whole collection for other changes
+                var indexes = new List<NSIndexPath>();
+                switch (e.Action) {
+                    case NotifyCollectionChangedAction.Add:
+                        for (int i = 0; i < e.NewItems.Count; i++) {
+                            indexes.Add(NSIndexPath.FromRowSection((nint)(e.NewStartingIndex + i),0));
+                        }
+                        this.Control.InsertItems(indexes.ToArray());
+                        break;
+                    case NotifyCollectionChangedAction.Remove:
+                        for (int i = 0; i< e.OldItems.Count; i++) {
+                            indexes.Add(NSIndexPath.FromRowSection((nint)(e.OldStartingIndex + i),0));
+                        }
+                        this.Control.DeleteItems(indexes.ToArray());
+                        break;
+                default:
+                        this.Control.ReloadData();
+                        break;
+                }
             } 
             catch { } // todo: determine why we are hiding a possible exception here
         }

--- a/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
@@ -171,10 +171,11 @@ namespace XLabs.Forms.Controls
         {
             if (e.PropertyName == "ItemsSource")
             {
-                var itemsSource = this.Element.ItemsSource as INotifyCollectionChanged;
-                if (itemsSource != null) 
+                var newItemsSource = this.Element.ItemsSource as INotifyCollectionChanged;
+                if (newItemsSource != null) 
                 {
-                    itemsSource.CollectionChanged -= DataCollectionChanged;
+                    newItemsSource.CollectionChanged += DataCollectionChanged;
+                    DataCollectionChanged(null,null);
                 }
             }
         }
@@ -188,10 +189,10 @@ namespace XLabs.Forms.Controls
         {
             if (e.PropertyName == "ItemsSource")
             {
-                var itemsSource = this.Element.ItemsSource as INotifyCollectionChanged;
-                if (itemsSource != null) 
+                var oldItemsSource = this.Element.ItemsSource as INotifyCollectionChanged;
+                if (oldItemsSource != null) 
                 {
-                    itemsSource.CollectionChanged += DataCollectionChanged;
+                    oldItemsSource.CollectionChanged -= DataCollectionChanged;
                 }
             }
         }


### PR DESCRIPTION
Current GridViewRenderer does not handle a change of item source elegantly, and instead ignores any change to its binding.  I changed the naming because it looks like there may have been confusion form the original writer (or from me, although inverting the +/- worked for me).  The DataCollectionChanged force-call is required once, otherwise there won't be any updates until the collection changes again (insert/delete)

Additionally ReloadData is a bit heavy if people are working with large collectionViews, I haven't made any changes there but it might be nice if people are modifying larger data sets (not rebinding)