### PR TITLE
Carousel fixes for swipe gestures, new property to get/set selected carousel page

### DIFF
--- a/Samples/XLabs.Sample/App.cs
+++ b/Samples/XLabs.Sample/App.cs
@@ -219,6 +219,7 @@ namespace XLabs.Sample
                 {"AutocompleteView",  typeof(AutoCompletePage)},
                 {"ButtonGroup", typeof(ButtonGroupPage)},
                 {"Calendar", typeof(CalendarPage)},
+				{"CarouselView", typeof(CarouselSample)},
                 {"CameraView", typeof(CameraViewPage)},
                 {"CheckBox", typeof(CheckBoxPage)},
                 {"CircleImage", typeof(CircleImagePage)},

--- a/Samples/XLabs.Sample/Pages/Controls/CarouselSample.xaml
+++ b/Samples/XLabs.Sample/Pages/Controls/CarouselSample.xaml
@@ -77,7 +77,7 @@
 						WinPhone="20,20,20,20" />
 		</StackLayout.Padding>
 
-		<lc:CarouselView x:TypeArguments="my:PageWidget" ViewModels="{Binding Models}" TemplateSelector="{StaticResource Carouselselector}" HeightRequest="100" Padding="10,25"/>
+		<lc:CarouselView x:TypeArguments="my:PageWidget" ViewModels="{Binding Models}" SelectedViewModel="{Binding SelectedModel}" TemplateSelector="{StaticResource Carouselselector}" HeightRequest="100" Padding="10,25"/>
 		<Label Text="The view obove is bound to a collection that contains workoders and message objects"/>
 		<Label Text="As you swipe back and forth the view uses it's template selector to determine which datatemplate to instantiate and bind to the current item."/>
 		<Label Text="If you have a single DataTemplate simply create the selector with one template and mark set the IsDefault property to true"/>

--- a/Samples/XLabs.Sample/Pages/Controls/CarouselSample.xaml
+++ b/Samples/XLabs.Sample/Pages/Controls/CarouselSample.xaml
@@ -77,7 +77,7 @@
 						WinPhone="20,20,20,20" />
 		</StackLayout.Padding>
 
-		<lc:CarouselView x:TypeArguments="my:PageWidget" ViewModels="{Binding Models}" SelectedViewModel="{Binding SelectedModel}" TemplateSelector="{StaticResource Carouselselector}" HeightRequest="100" Padding="10,25"/>
+		<lc:CarouselView x:TypeArguments="my:PageWidget" ViewModels="{Binding Models}" TemplateSelector="{StaticResource Carouselselector}" HeightRequest="100" Padding="10,25"/>
 		<Label Text="The view obove is bound to a collection that contains workoders and message objects"/>
 		<Label Text="As you swipe back and forth the view uses it's template selector to determine which datatemplate to instantiate and bind to the current item."/>
 		<Label Text="If you have a single DataTemplate simply create the selector with one template and mark set the IsDefault property to true"/>

--- a/Samples/XLabs.Sample/Pages/Controls/CarouselSample.xaml.cs
+++ b/Samples/XLabs.Sample/Pages/Controls/CarouselSample.xaml.cs
@@ -9,7 +9,6 @@
     {
         public CarouselSample()
         {
-		{
             InitializeComponent();
             BindingContext = new CarouselVm();
         }
@@ -75,13 +74,6 @@
         }
 
         public ObservableCollection<PageWidget> Models { get; set; }
-
-		private PageWidget _SelectedModel;
-		public PageWidget SelectedModel 
-		{
-		 	get { return _SelectedModel; }  
-			set { SetField (ref _SelectedModel, value);  }
-		}
     }
 
     public class PageWidget

--- a/Samples/XLabs.Sample/Pages/Controls/CarouselSample.xaml.cs
+++ b/Samples/XLabs.Sample/Pages/Controls/CarouselSample.xaml.cs
@@ -74,6 +74,13 @@
         }
 
         public ObservableCollection<PageWidget> Models { get; set; }
+
+		private PageWidget _SelectedModel;
+		public PageWidget SelectedModel 
+		{
+			get { return _SelectedModel; }  
+			set { SetField (ref _SelectedModel, value);  }
+		}
     }
 
     public class PageWidget

--- a/Samples/XLabs.Sample/Pages/Controls/CarouselSample.xaml.cs
+++ b/Samples/XLabs.Sample/Pages/Controls/CarouselSample.xaml.cs
@@ -9,6 +9,7 @@
     {
         public CarouselSample()
         {
+		{
             InitializeComponent();
             BindingContext = new CarouselVm();
         }
@@ -74,6 +75,13 @@
         }
 
         public ObservableCollection<PageWidget> Models { get; set; }
+
+		private PageWidget _SelectedModel;
+		public PageWidget SelectedModel 
+		{
+		 	get { return _SelectedModel; }  
+			set { SetField (ref _SelectedModel, value);  }
+		}
     }
 
     public class PageWidget

--- a/src/Forms/XLabs.Forms.iOS/Controls/GesturesContentView/GesturesContentViewRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/GesturesContentView/GesturesContentViewRenderer.cs
@@ -1,6 +1,7 @@
 using Xamarin.Forms;
 
 using XLabs.Forms.Controls;
+using System.Linq;
 
 [assembly: ExportRenderer(typeof(GesturesContentView),typeof(GesturesContentViewRenderer))]
 
@@ -46,7 +47,8 @@ namespace XLabs.Forms.Controls
                     if (x.State == UIGestureRecognizerState.Ended)
                     {
                         var viewpoint = x.LocationInView(this);
-                        this.Element.ProcessGesture(new GestureResult { GestureType = GestureType.SingleTap, Direction = Directionality.None, Origin = viewpoint.ToPoint() });                        
+						this.Element.ProcessGesture(new GestureResult { GestureType = GestureType.SingleTap, Direction = Directionality.None, Origin = viewpoint.ToPoint(),
+							ViewStack = Element.ExcludeChildren ? ViewsContaining(viewpoint.ToPoint()) : null});                        
                     }
                 }){NumberOfTapsRequired = 1});
             //Double Tap
@@ -55,7 +57,8 @@ namespace XLabs.Forms.Controls
                     if (x.State == UIGestureRecognizerState.Ended)
                     {
                         var viewpoint = x.LocationInView(this);
-                        this.Element.ProcessGesture(new GestureResult { GestureType = GestureType.DoubleTap, Direction = Directionality.None, Origin = viewpoint.ToPoint() });                        
+						this.Element.ProcessGesture(new GestureResult { GestureType = GestureType.DoubleTap, Direction = Directionality.None, Origin = viewpoint.ToPoint(),
+							ViewStack = Element.ExcludeChildren ? ViewsContaining(viewpoint.ToPoint()) : null});                        
                     }
                 }) { NumberOfTapsRequired = 2 });
             // Longpress
@@ -64,32 +67,67 @@ namespace XLabs.Forms.Controls
                     if (x.State == UIGestureRecognizerState.Ended)
                     {
                         var viewpoint = x.LocationInView(this);
-                        this.Element.ProcessGesture(new GestureResult { GestureType = GestureType.LongPress, Direction = Directionality.None, Origin = viewpoint.ToPoint() });                        
+						this.Element.ProcessGesture(new GestureResult { GestureType = GestureType.LongPress, Direction = Directionality.None, Origin = viewpoint.ToPoint(),
+							ViewStack = Element.ExcludeChildren ? ViewsContaining(viewpoint.ToPoint()) : null});                        
                     }
                 }));
-            // Swipe
-            this._recognizers.Add(new UISwipeGestureRecognizer((x) =>
-                {
-                    if (x.State == UIGestureRecognizerState.Began)
-                    {
-                        this._swipeStart = x.LocationInView(this).ToPoint();
-                    }
-                    if (x.State == UIGestureRecognizerState.Ended)
-                    {
-                        var endpoint = x.LocationInView(this).ToPoint();
-                        var distance = this._swipeStart.Distance(endpoint);
-                        var distanceX = Math.Abs(this._swipeStart.X - endpoint.X);
-                        var distanceY = Math.Abs(this._swipeStart.Y - endpoint.Y);
-                        var direction = Directionality.None;
-                        direction |= ((x.Direction & UISwipeGestureRecognizerDirection.Left) == UISwipeGestureRecognizerDirection.Left ? Directionality.Left : Directionality.None);
-                        direction |= ((x.Direction & UISwipeGestureRecognizerDirection.Right) == UISwipeGestureRecognizerDirection.Right ? Directionality.Right : Directionality.None);
-                        direction |= ((x.Direction & UISwipeGestureRecognizerDirection.Up) == UISwipeGestureRecognizerDirection.Up ? Directionality.Up : Directionality.None);
-                        direction |= ((x.Direction & UISwipeGestureRecognizerDirection.Down) == UISwipeGestureRecognizerDirection.Down ? Directionality.Down : Directionality.None);
-
-                        this.Element.ProcessGesture(new GestureResult { Direction = direction, GestureType = GestureType.Swipe, HorizontalDistance = distanceX, VerticalDistance = distanceY, Origin = _swipeStart, Length = distance });
-                    }
-                }){ Direction = AllDirections,NumberOfTouchesRequired = 1});
+            // Swipe left
+			this._recognizers.Add(new UISwipeGestureRecognizer(SwipeRecognizer){ Direction =  UISwipeGestureRecognizerDirection.Left, NumberOfTouchesRequired = 1});
+			// Swipe right
+			this._recognizers.Add(new UISwipeGestureRecognizer(SwipeRecognizer){ Direction =  UISwipeGestureRecognizerDirection.Right, NumberOfTouchesRequired = 1});
+			// Swipe up
+			this._recognizers.Add(new UISwipeGestureRecognizer(SwipeRecognizer){ Direction =  UISwipeGestureRecognizerDirection.Up, NumberOfTouchesRequired = 1});
+			// Swipe down
+			this._recognizers.Add(new UISwipeGestureRecognizer(SwipeRecognizer){ Direction =  UISwipeGestureRecognizerDirection.Down, NumberOfTouchesRequired = 1});
         }
+
+		void SwipeRecognizer(UISwipeGestureRecognizer x)
+		{
+			if (x.State == UIGestureRecognizerState.Began)
+			{
+				this._swipeStart = x.LocationInView(this).ToPoint();
+			}
+			if (x.State == UIGestureRecognizerState.Ended)
+			{
+				var endpoint = x.LocationInView(this).ToPoint();
+				var distance = this._swipeStart.Distance(endpoint);
+				var distanceX = Math.Abs(this._swipeStart.X - endpoint.X);
+				var distanceY = Math.Abs(this._swipeStart.Y - endpoint.Y);
+				var direction = Directionality.None;
+				direction |= ((x.Direction & UISwipeGestureRecognizerDirection.Left) == UISwipeGestureRecognizerDirection.Left ? Directionality.Left : Directionality.None);
+				direction |= ((x.Direction & UISwipeGestureRecognizerDirection.Right) == UISwipeGestureRecognizerDirection.Right ? Directionality.Right : Directionality.None);
+				direction |= ((x.Direction & UISwipeGestureRecognizerDirection.Up) == UISwipeGestureRecognizerDirection.Up ? Directionality.Up : Directionality.None);
+				direction |= ((x.Direction & UISwipeGestureRecognizerDirection.Down) == UISwipeGestureRecognizerDirection.Down ? Directionality.Down : Directionality.None);
+
+				this.Element.ProcessGesture(new GestureResult { Direction = direction, GestureType = GestureType.Swipe, HorizontalDistance = distanceX, VerticalDistance = distanceY, Origin = _swipeStart, Length = distance, 
+					ViewStack = Element.ExcludeChildren ? ViewsContaining(_swipeStart) : null});
+			}
+		}
+
+		private List<View> ViewsContaining(Point pt)
+		{
+			var ret = new List<View>();
+			return ViewsContainingImpl(pt, ret, this).OrderByDescending(x=>x.Width * x.Height).ToList();
+		}
+
+		private IEnumerable<View> ViewsContainingImpl(Point pt,List<View>views, UIView root )
+		{
+			if (root != null && root.Subviews != null) 
+			{
+				for (var i = 0; i < root.Subviews.Count (); i++) 
+				{
+					var child = root.Subviews [i];
+					var bounds = child.Bounds;
+					var ver = child as IVisualElementRenderer;
+					if (ver == null || !(ver.Element is View) || !bounds.Contains (Convert.ToInt32 (pt.X), Convert.ToInt32 (pt.Y)))
+						continue;
+					views.Add (ver.Element as View);
+					//check to see if this containing child has any other containing children
+					ViewsContainingImpl (pt, views, child);
+				}
+			}
+			return views;
+		}
 
         /// <summary>When the underlying element is changed we detach from the old, and attach to the new</summary>
         /// <param name="e">The <see cref="ElementChangedEventArgs{GesturesContentView}"/> instance containing the event data.</param>

--- a/src/Forms/XLabs.Forms/Controls/CarouselView.cs
+++ b/src/Forms/XLabs.Forms/Controls/CarouselView.cs
@@ -98,6 +98,10 @@ namespace XLabs.Forms.Controls
 		/// </summary>
 		public static BindableProperty ViewModelsProperty = BindableProperty.Create<CarouselView<T>, ObservableCollection<T>>(x => x.ViewModels, default(ObservableCollection<T>),BindingMode.OneWay,null,ViewModelsChanged);
 		/// <summary>
+		/// Property defnition for the <see cref="SelectedViewModel" /> property
+		/// </summary>
+		public static BindableProperty SelectedViewModelProperty = BindableProperty.Create<CarouselView<T>, T>(x => x.SelectedViewModel, default(T),BindingMode.TwoWay,null,SelectedViewModelChanged);
+		/// <summary>
 		/// Property definition for the <see cref="TemplateSelector" /> property
 		/// </summary>
 		public static readonly BindableProperty TemplateSelectorProperty = BindableProperty.Create<CarouselView<T>, TemplateSelector>(x => x.TemplateSelector, default(TemplateSelector),BindingMode.OneWay,null,TemplateSelectorChanged);
@@ -191,6 +195,15 @@ namespace XLabs.Forms.Controls
 		}
 
 		/// <summary>
+		/// The selected view model.
+		/// </summary>
+		/// <value>The selected view model.</value>
+		public T SelectedViewModel {
+			get { return (T)GetValue (SelectedViewModelProperty); }
+			set { SetValue (SelectedViewModelProperty, value); }
+		}
+
+		/// <summary>
 		/// Used to match a type with a datatemplate
 		/// <see cref="TemplateSelector" />
 		/// </summary>
@@ -232,20 +245,30 @@ namespace XLabs.Forms.Controls
         private void SwitchView(bool increment)
         {
             var newval = this.currentview + (increment ? 1 : -1);
-            
-            if (newval < 0 || newval > ViewModels.Count() - 1) return;
-            var oldview = this.currentview >=0 ?  ViewModels[this.currentview] as ICarouselView : null;
-            var newview = ViewModels[newval] as ICarouselView;
-
-            myGrid.Children.Clear();
-            if(oldview != null) oldview.Hiding();
-            if(newview != null) newview.Showing();
-            this.currentview = newval;
-            this.contentView.ViewModel = ViewModels[this.currentview];
-            if(oldview != null) oldview.Hiden();
-            if(newview != null) newview.Shown();
-            this.myGrid.Children.Add(this.marker, this.currentview, 0);
+			SwitchView (newval);
         }
+
+		/// <summary>
+		/// Switches the view. Based on absolute position.
+		/// </summary>
+		/// <param name="newPosition">New position.</param>
+		private void SwitchView(int newval)
+		{
+			if (newval < 0 || newval > ViewModels.Count() - 1) return;
+			var oldview = this.currentview >=0 ?  ViewModels[this.currentview] as ICarouselView : null;
+			var newview = ViewModels[newval] as ICarouselView;
+
+			myGrid.Children.Clear();
+			if(oldview != null) oldview.Hiding();
+			if(newview != null) newview.Showing();
+			this.currentview = newval;
+			var newVm = ViewModels [this.currentview];
+			this.contentView.ViewModel = newVm;
+			this.SelectedViewModel = newVm;
+			if(oldview != null) oldview.Hiden();
+			if(newview != null) newview.Shown();
+			this.myGrid.Children.Add(this.marker, this.currentview, 0);
+		}
 
         /// <summary>
         /// Shows the tick changed.
@@ -309,6 +332,24 @@ namespace XLabs.Forms.Controls
                     break;
             }
         }
+
+		/// <summary>
+		///The selected viewmodel changed.
+		/// </summary>
+		/// <param name="bo">The bo.</param>
+		/// <param name="oldval">The oldval.</param>
+		/// <param name="newval">The newval.</param>
+		/// <exception cref="XLabs.Forms.Exceptions.InvalidBindableException"></exception>
+		private static void SelectedViewModelChanged(BindableObject bo, T oldval, T newval)
+		{
+			var cv = bo as CarouselView<T>;
+			if (cv == null)
+				throw new InvalidBindableException(bo, typeof(CarouselView<T>));
+
+			var newPosition = cv.ViewModels.IndexOf (newval);
+			if(newPosition >= 0 && newPosition != cv.currentview)	
+				cv.SwitchView (newPosition);
+		}
 
         /// <summary>
         /// Shows the tickchanged.

--- a/src/Forms/XLabs.Forms/Controls/CarouselView.cs
+++ b/src/Forms/XLabs.Forms/Controls/CarouselView.cs
@@ -98,10 +98,6 @@ namespace XLabs.Forms.Controls
 		/// </summary>
 		public static BindableProperty ViewModelsProperty = BindableProperty.Create<CarouselView<T>, ObservableCollection<T>>(x => x.ViewModels, default(ObservableCollection<T>),BindingMode.OneWay,null,ViewModelsChanged);
 		/// <summary>
-		/// Property defnition for the <see cref="SelectedViewModel" /> property
-		/// </summary>
-		public static BindableProperty SelectedViewModelProperty = BindableProperty.Create<CarouselView<T>, T>(x => x.SelectedViewModel, default(T),BindingMode.TwoWay,null,SelectedViewModelChanged);
-		/// <summary>
 		/// Property definition for the <see cref="TemplateSelector" /> property
 		/// </summary>
 		public static readonly BindableProperty TemplateSelectorProperty = BindableProperty.Create<CarouselView<T>, TemplateSelector>(x => x.TemplateSelector, default(TemplateSelector),BindingMode.OneWay,null,TemplateSelectorChanged);
@@ -195,15 +191,6 @@ namespace XLabs.Forms.Controls
 		}
 
 		/// <summary>
-		/// The selected view model.
-		/// </summary>
-		/// <value>The selected view model.</value>
-		public T SelectedViewModel {
-			get { return (T)GetValue (SelectedViewModelProperty); }
-			set { SetValue (SelectedViewModelProperty, value); }
-		}
-
-		/// <summary>
 		/// Used to match a type with a datatemplate
 		/// <see cref="TemplateSelector" />
 		/// </summary>
@@ -245,30 +232,20 @@ namespace XLabs.Forms.Controls
         private void SwitchView(bool increment)
         {
             var newval = this.currentview + (increment ? 1 : -1);
-			SwitchView (newval);
+            
+            if (newval < 0 || newval > ViewModels.Count() - 1) return;
+            var oldview = this.currentview >=0 ?  ViewModels[this.currentview] as ICarouselView : null;
+            var newview = ViewModels[newval] as ICarouselView;
+
+            myGrid.Children.Clear();
+            if(oldview != null) oldview.Hiding();
+            if(newview != null) newview.Showing();
+            this.currentview = newval;
+            this.contentView.ViewModel = ViewModels[this.currentview];
+            if(oldview != null) oldview.Hiden();
+            if(newview != null) newview.Shown();
+            this.myGrid.Children.Add(this.marker, this.currentview, 0);
         }
-
-		/// <summary>
-		/// Switches the view. Based on absolute position.
-		/// </summary>
-		/// <param name="newPosition">New position.</param>
-		private void SwitchView(int newval)
-		{
-			if (newval < 0 || newval > ViewModels.Count() - 1) return;
-			var oldview = this.currentview >=0 ?  ViewModels[this.currentview] as ICarouselView : null;
-			var newview = ViewModels[newval] as ICarouselView;
-
-			myGrid.Children.Clear();
-			if(oldview != null) oldview.Hiding();
-			if(newview != null) newview.Showing();
-			this.currentview = newval;
-			var newVm = ViewModels [this.currentview];
-			this.contentView.ViewModel = newVm;
-			this.SelectedViewModel = newVm;
-			if(oldview != null) oldview.Hiden();
-			if(newview != null) newview.Shown();
-			this.myGrid.Children.Add(this.marker, this.currentview, 0);
-		}
 
         /// <summary>
         /// Shows the tick changed.
@@ -332,24 +309,6 @@ namespace XLabs.Forms.Controls
                     break;
             }
         }
-
-		/// <summary>
-		///The selected viewmodel changed.
-		/// </summary>
-		/// <param name="bo">The bo.</param>
-		/// <param name="oldval">The oldval.</param>
-		/// <param name="newval">The newval.</param>
-		/// <exception cref="XLabs.Forms.Exceptions.InvalidBindableException"></exception>
-		private static void SelectedViewModelChanged(BindableObject bo, T oldval, T newval)
-		{
-			var cv = bo as CarouselView<T>;
-			if (cv == null)
-				throw new InvalidBindableException(bo, typeof(CarouselView<T>));
-
-			var newPosition = cv.ViewModels.IndexOf (newval);
-			if(newPosition >= 0 && newPosition != cv.currentview)	
-				cv.SwitchView (newPosition);
-		}
 
         /// <summary>
         /// Shows the tickchanged.

--- a/src/Forms/XLabs.Forms/Controls/CarouselView.cs
+++ b/src/Forms/XLabs.Forms/Controls/CarouselView.cs
@@ -251,7 +251,7 @@ namespace XLabs.Forms.Controls
 		/// <summary>
 		/// Switches the view. Based on absolute position.
 		/// </summary>
-		/// <param name="newPosition">New position.</param>
+		/// <param name="newval">New position.</param>
 		private void SwitchView(int newval)
 		{
 			if (newval < 0 || newval > ViewModels.Count() - 1) return;


### PR DESCRIPTION
Updated the CarouselView control so that swiping works on iOS. 
Also added new property so that consumers can determine / set the current selected item.