### PR TITLE
Added Android namespace

### DIFF
--- a/src/Platform/XLabs.Platform.Droid/Services/Media/MediaPickerActivity.cs
+++ b/src/Platform/XLabs.Platform.Droid/Services/Media/MediaPickerActivity.cs
@@ -8,6 +8,7 @@ namespace XLabs.Platform.Services.Media
 	using System.Threading;
 	using System.Threading.Tasks;
 
+	using Android;
 	using Android.App;
 	using Android.Content;
 	using Android.Database;


### PR DESCRIPTION
Added Android namespace, otherwise Manifest is not found in the new permission check.

if (global::Android.OS.Build.VERSION.Release == "6.0")
{
  if (CheckSelfPermission(Manifest.Permission.Camera) != Android.Content.PM.Permission.Granted)
  {
    RequestPermissions(new string[] { Manifest.Permission.Camera }, 1);
  }
}