### PR TITLE
BaseCellView calls for a context and a cell.

### DIFF
--- a/src/Forms/XLabs.Forms.Droid/Controls/ExtendedTextCell/ExtendedTextCellRenderer.cs
+++ b/src/Forms/XLabs.Forms.Droid/Controls/ExtendedTextCell/ExtendedTextCellRenderer.cs
@@ -55,7 +55,7 @@ namespace XLabs.Forms.Controls
 
             if (convertView == null)
             {
-                convertView = new BaseCellView(context);
+                convertView = new BaseCellView(context, view);
             }
 
             var cellView = convertView as BaseCellView;


### PR DESCRIPTION
Passed along "item", a Cell cast as an ExtendedTextCell to BaseCellView which is requesting both a context and a cell.

Error	CS7036	There is no argument given that corresponds to the required formal parameter 'cell' of 'BaseCellView.BaseCellView(Context, Cell)'	XLabs.Forms.Droid	\Xamarin-Forms-Labs\src\Forms\XLabs.Forms.Droid\Controls\ExtendedTextCell\ExtendedTextCellRenderer.cs	58