### PR TITLE
[iOS] fix GridViewRenderer.DataCollectionChanged

### DIFF
--- a/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridCollectionView.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridCollectionView.cs
@@ -136,6 +136,11 @@ namespace XLabs.Forms.Controls
 
             base.Draw (rect);
         }
+
+        public override CGSize SizeThatFits(CGSize size)
+        {
+            return ItemSize;
+        }
     }
 }
 

--- a/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
@@ -122,7 +122,7 @@ namespace XLabs.Forms.Controls
             {
                 if (Control == null)
                 {
-                    var collectionView = new GridCollectionView {
+                    var collectionView = new GridCollectionView() {
                         AllowsMultipleSelection = false,
                         SelectionEnable = e.NewElement.SelectionEnabled,
                         ContentInset =  new UIEdgeInsets ((float)this.Element.Padding.Top, (float)this.Element.Padding.Left, (float)this.Element.Padding.Bottom, (float)this.Element.Padding.Right),
@@ -187,7 +187,7 @@ namespace XLabs.Forms.Controls
         /// <param name="e">The <see cref="System.ComponentModel.PropertyChangedEventArgs"/> instance containing the event data.</param>
         private void ElementPropertyChanged (object sender, System.ComponentModel.PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == "ItemsSource")
+            if (e.PropertyName == GridView.ItemsSourceProperty.PropertyName)
             {
                 var newItemsSource = this.Element.ItemsSource as INotifyCollectionChanged;
                 if (newItemsSource != null) 

--- a/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/GridView/GridViewRenderer.cs
@@ -225,27 +225,34 @@ namespace XLabs.Forms.Controls
             InvokeOnMainThread (()=> {
                 try 
                 {
-                    if(this.Control == null) return;
+                    if(this.Control == null)
+                        return;
 
-                    // try to handle add or remove operations gracefully, just reload the whole collection for other changes
-                    var indexes = new List<NSIndexPath>();
-                    switch (e.Action) {
-                        case NotifyCollectionChangedAction.Add:
-                            for (int i = 0; i < e.NewItems.Count; i++) {
-                                indexes.Add(NSIndexPath.FromRowSection((nint)(e.NewStartingIndex + i),0));
-                            }
-                            this.Control.InsertItems(indexes.ToArray());
-                            break;
-                        case NotifyCollectionChangedAction.Remove:
-                            for (int i = 0; i< e.OldItems.Count; i++) {
-                                indexes.Add(NSIndexPath.FromRowSection((nint)(e.OldStartingIndex + i),0));
-                            }
-                            this.Control.DeleteItems(indexes.ToArray());
-                            break;
-                        default:
-                            this.Control.ReloadData();
-                            break;
-                    }
+                    this.Control.ReloadData();
+
+                    // TODO: try to handle add or remove operations gracefully, just reload the whole collection for other changes
+                    // InsertItems, DeleteItems or ReloadItems can cause
+                    // *** Assertion failure in -[XLabs_Forms_Controls_GridCollectionView _endItemAnimationsWithInvalidationContext:tentativelyForReordering:],
+                    // BuildRoot/Library/Caches/com.apple.xbs/Sources/UIKit_Sim/UIKit-3512.30.14/UICollectionView.m:4324
+
+//                    var indexes = new List<NSIndexPath>();
+//                    switch (e.Action) {
+//                        case NotifyCollectionChangedAction.Add:
+//                            for (int i = 0; i < e.NewItems.Count; i++) {
+//                                indexes.Add(NSIndexPath.FromRowSection((nint)(e.NewStartingIndex + i),0));
+//                            }
+//                            this.Control.InsertItems(indexes.ToArray());
+//                            break;
+//                        case NotifyCollectionChangedAction.Remove:
+//                            for (int i = 0; i< e.OldItems.Count; i++) {
+//                                indexes.Add(NSIndexPath.FromRowSection((nint)(e.OldStartingIndex + i),0));
+//                            }
+//                            this.Control.DeleteItems(indexes.ToArray());
+//                            break;
+//                        default:
+//                            this.Control.ReloadData();
+//                            break;
+//                    }
                 } 
                 catch { } // todo: determine why we are hiding a possible exception here
             });

--- a/src/Forms/XLabs.Forms/Controls/GridView.cs
+++ b/src/Forms/XLabs.Forms/Controls/GridView.cs
@@ -25,158 +25,198 @@ using Xamarin.Forms;
 
 namespace XLabs.Forms.Controls
 {
-	/// <summary>
-	/// Class GridView.
-	/// </summary>
-	public class GridView : ContentView
-	{
-		/// <summary>
-		/// Initializes a new instance of the <see cref="GridView"/> class.
-		/// </summary>
-		public GridView ()
-		{
-			SelectionEnabled = true;
-		}
+    /// <summary>
+    /// Class GridView.
+    /// </summary>
+    public class GridView : View
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GridView"/> class.
+        /// </summary>
+        public GridView()
+        {
+            SelectionEnabled = true;
+        }
 
+        //
+        // Static Fields
+        //
+        /// <summary>
+        /// The items source property
+        /// </summary>
+        public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create("ItemsSource", typeof(IEnumerable), typeof(GridView), null, BindingMode.OneWay, null, null, null, null);
 
-		//
-		// Static Fields
-		//
-		/// <summary>
-		/// The items source property
-		/// </summary>
-		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create ("ItemsSource", typeof(IEnumerable), typeof(GridView), null, BindingMode.OneWay, null, null, null, null);
+        /// <summary>
+        /// The item template property
+        /// </summary>
+        public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create("ItemTemplate", typeof(DataTemplate), typeof(GridView), null, BindingMode.OneWay, null, null, null, null);
 
-		/// <summary>
-		/// The item template property
-		/// </summary>
-		public static readonly BindableProperty ItemTemplateProperty = BindableProperty.Create ("ItemTemplate", typeof(DataTemplate), typeof(GridView), null, BindingMode.OneWay, null, null, null, null);
+        /// <summary>
+        /// The row spacing property
+        /// </summary>
+        public static readonly BindableProperty RowSpacingProperty = BindableProperty.Create("RowSpacing", typeof(double), typeof(GridView), 0.0, BindingMode.OneWay, null, null, null, null);
 
-		/// <summary>
-		/// The row spacing property
-		/// </summary>
-		public static readonly BindableProperty RowSpacingProperty = BindableProperty.Create ("RowSpacing", typeof(double), typeof(GridView), (double)0, BindingMode.OneWay, null, null, null, null);
+        /// <summary>
+        /// The column spacing property
+        /// </summary>
+        public static readonly BindableProperty ColumnSpacingProperty = BindableProperty.Create("ColumnSpacing", typeof(double), typeof(GridView), 0.0, BindingMode.OneWay, null, null, null, null);
 
-		/// <summary>
-		/// The column spacing property
-		/// </summary>
-		public static readonly BindableProperty ColumnSpacingProperty = BindableProperty.Create ("ColumnSpacing", typeof(double), typeof(GridView), (double)0, BindingMode.OneWay, null, null, null, null);
+        /// <summary>
+        /// The item width property
+        /// </summary>
+        public static readonly BindableProperty ItemWidthProperty = BindableProperty.Create("ItemWidth", typeof(double), typeof(GridView), 100.0, BindingMode.OneWay, null, null, null, null);
 
-		/// <summary>
-		/// The item width property
-		/// </summary>
-		public static readonly BindableProperty ItemWidthProperty = BindableProperty.Create ("ItemWidth", typeof(double), typeof(GridView), (double)100, BindingMode.OneWay, null, null, null, null);
+        /// <summary>
+        /// The item height property
+        /// </summary>
+        public static readonly BindableProperty ItemHeightProperty = BindableProperty.Create("ItemHeight", typeof(double), typeof(GridView), 100.0, BindingMode.OneWay, null, null, null, null);
 
-		/// <summary>
-		/// The item height property
-		/// </summary>
-		public static readonly BindableProperty ItemHeightProperty = BindableProperty.Create ("ItemHeight", typeof(double), typeof(GridView), (double)100, BindingMode.OneWay, null, null, null, null);
+        /// <summary>
+        /// The padding property
+        /// </summary>
+        public static readonly BindableProperty PaddingProperty = BindableProperty.Create<GridView, Thickness>(view => view.Padding, new Thickness(0), BindingMode.OneWay);
 
-		//
-		// Properties
-		//
-		/// <summary>
-		/// Gets or sets the items source.
-		/// </summary>
-		/// <value>The items source.</value>
-		public IEnumerable ItemsSource {
-			get {
-				return (IEnumerable)base.GetValue (GridView.ItemsSourceProperty);
-			}
-			set {
-				base.SetValue (GridView.ItemsSourceProperty, value);
-			}
-		}
+        //
+        // Properties
+        //
+        /// <summary>
+        /// Gets or sets the items source.
+        /// </summary>
+        /// <value>The items source.</value>
+        public IEnumerable ItemsSource
+        {
+            get
+            {
+                return (IEnumerable)base.GetValue(GridView.ItemsSourceProperty);
+            }
+            set
+            {
+                base.SetValue(GridView.ItemsSourceProperty, value);
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the item template.
-		/// </summary>
-		/// <value>The item template.</value>
-		public DataTemplate ItemTemplate {
-			get {
-				return (DataTemplate)base.GetValue (GridView.ItemTemplateProperty);
-			}
-			set {
-				base.SetValue (GridView.ItemTemplateProperty, value);
-			}
-		}
+        /// <summary>
+        /// Gets or sets the item template.
+        /// </summary>
+        /// <value>The item template.</value>
+        public DataTemplate ItemTemplate
+        {
+            get
+            {
+                return (DataTemplate)base.GetValue(GridView.ItemTemplateProperty);
+            }
+            set
+            {
+                base.SetValue(GridView.ItemTemplateProperty, value);
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the row spacing.
-		/// </summary>
-		/// <value>The row spacing.</value>
-		public double RowSpacing {
-			get {
-				return (double)base.GetValue (GridView.RowSpacingProperty);
-			}
-			set {
-				base.SetValue (GridView.RowSpacingProperty, value);
-			}
-		}
+        /// <summary>
+        /// Gets or sets the row spacing.
+        /// </summary>
+        /// <value>The row spacing.</value>
+        public double RowSpacing
+        {
+            get
+            {
+                return (double)base.GetValue(GridView.RowSpacingProperty);
+            }
+            set
+            {
+                base.SetValue(GridView.RowSpacingProperty, value);
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the column spacing.
-		/// </summary>
-		/// <value>The column spacing.</value>
-		public double ColumnSpacing {
-			get {
-				return (double)base.GetValue (GridView.ColumnSpacingProperty);
-			}
-			set {
-				base.SetValue (GridView.ColumnSpacingProperty, value);
-			}
-		}
+        /// <summary>
+        /// Gets or sets the column spacing.
+        /// </summary>
+        /// <value>The column spacing.</value>
+        public double ColumnSpacing
+        {
+            get
+            {
+                return (double)base.GetValue(GridView.ColumnSpacingProperty);
+            }
+            set
+            {
+                base.SetValue(GridView.ColumnSpacingProperty, value);
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the width of the item.
-		/// </summary>
-		/// <value>The width of the item.</value>
-		public double ItemWidth {
-			get {
-				return (double)base.GetValue (GridView.ItemWidthProperty);
-			}
-			set {
-				base.SetValue (GridView.ItemWidthProperty, value);
-			}
-		}
+        /// <summary>
+        /// Gets or sets the width of the item.
+        /// </summary>
+        /// <value>The width of the item.</value>
+        public double ItemWidth
+        {
+            get
+            {
+                return (double)base.GetValue(GridView.ItemWidthProperty);
+            }
+            set
+            {
+                base.SetValue(GridView.ItemWidthProperty, value);
+            }
+        }
 
-		/// <summary>
-		/// Gets or sets the height of the item.
-		/// </summary>
-		/// <value>The height of the item.</value>
-		public double ItemHeight {
-			get {
-				return (double)base.GetValue (GridView.ItemHeightProperty);
-			}
-			set {
-				base.SetValue (GridView.ItemHeightProperty, value);
-			}
-		}
+        /// <summary>
+        /// Gets or sets the height of the item.
+        /// </summary>
+        /// <value>The height of the item.</value>
+        public double ItemHeight
+        {
+            get
+            {
+                return (double)base.GetValue(GridView.ItemHeightProperty);
+            }
+            set
+            {
+                base.SetValue(GridView.ItemHeightProperty, value);
+            }
+        }
 
-		/// <summary>
-		/// Occurs when item is selected.
-		/// </summary>
-		public event EventHandler<EventArgs<object>> ItemSelected;
+        /// <summary>
+        /// Gets or sets the padding.
+        /// </summary>
+        /// <value>The padding.</value>
+        public Thickness Padding
+        {
+            get
+            {
+                return (Thickness)base.GetValue(PaddingProperty);
+            }
+            set
+            {
+                base.SetValue(PaddingProperty, value);
+            }
+        }
 
-		/// <summary>
-		/// Invokes the item selected event.
-		/// </summary>
-		/// <param name="sender">The sender.</param>
-		/// <param name="item">Item.</param>
-		public void InvokeItemSelectedEvent (object sender, object item)
-		{
-			if (this.ItemSelected != null) {
-				this.ItemSelected.Invoke (sender, new EventArgs<object> (item));
-			}
-		}
+        /// <summary>
+        /// Occurs when item is selected.
+        /// </summary>
+        public event EventHandler<EventArgs<object>> ItemSelected;
 
-		/// <summary>
-		/// Gets or sets a value indicating whether [selection enabled].
-		/// </summary>
-		/// <value><c>true</c> if [selection enabled]; otherwise, <c>false</c>.</value>
-		public bool SelectionEnabled {
-			get;
-			set;
-		}
-	}
+        /// <summary>
+        /// Invokes the item selected event.
+        /// </summary>
+        /// <param name="sender">The sender.</param>
+        /// <param name="item">Item.</param>
+        public void InvokeItemSelectedEvent(object sender, object item)
+        {
+            if (this.ItemSelected != null)
+            {
+                this.ItemSelected.Invoke(sender, new EventArgs<object>(item));
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether [selection enabled].
+        /// </summary>
+        /// <value><c>true</c> if [selection enabled]; otherwise, <c>false</c>.</value>
+        public bool SelectionEnabled
+        {
+            get;
+            set;
+        }
+    }
 }


### PR DESCRIPTION
InsertItems, DeleteItems or ReloadItems can cause
*** Assertion failure in -[XLabs_Forms_Controls_GridCollectionView _endItemAnimationsWithInvalidationContext:tentativelyForReordering:], BuildRoot/Library/Caches/com.apple.xbs/Sources/UIKit_Sim/UIKit-3512.30.14/UICollectionView.m:4324