### PR TITLE
iOS CalendarViewRenderer: fix NullReferenceException

### DIFF
--- a/src/Forms/XLabs.Forms.iOS/Controls/Calendar/CalendarViewRenderer.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/Calendar/CalendarViewRenderer.cs
@@ -52,7 +52,7 @@ namespace XLabs.Forms.Controls
         {
             base.OnElementChanged(e);
 
-            if (e.NewElement == null) return;
+            if (disposed || e.NewElement == null) return;
 
             if (Control == null)
             {


### PR DESCRIPTION
When using the calendar view on iOS together with a MaterDetailPage, the app crashes when changing pages.