### PR TITLE
Prevent email attachments from not showing up on Android M or higher

### DIFF
--- a/src/Platform/XLabs.Platform.Droid/Extensions/IntentExtensions.cs
+++ b/src/Platform/XLabs.Platform.Droid/Extensions/IntentExtensions.cs
@@ -3,8 +3,8 @@
 // Author           : XLabs Team
 // Created          : 12-27-2015
 // 
-// Last Modified By : XLabs Team
-// Last Modified On : 01-04-2016
+// Last Modified By : Tim Klingeleers
+// Last Modified On : 03-27-2016
 // ***********************************************************************
 // <copyright file="IntentExtensions.cs" company="XLabs Team">
 //     Copyright (c) XLabs Team. All rights reserved.
@@ -24,6 +24,7 @@ using System.Linq;
 using Android.Content;
 using Android.Net;
 using Android.OS;
+using Android.Support.V4.Content;
 
 namespace XLabs.Platform
 {
@@ -31,35 +32,77 @@ namespace XLabs.Platform
     /// Class IntentExtensions.
     /// </summary>
     public static class IntentExtensions
-  {
+    {
         /// <summary>
         /// Adds the attachments.
         /// </summary>
         /// <param name="intent">The intent.</param>
         /// <param name="attachments">The attachments.</param>
-    public static void AddAttachments(this Intent intent, IEnumerable<string> attachments)
-    {
-      if (attachments == null || !attachments.Any())
-      {
-        Android.Util.Log.Warn("Intent.AddAttachments", "No attachments to attach.");
-        return;
-      }
-
-      IList<IParcelable> uris = new List<IParcelable>();
-      foreach (var attachment in attachments)
-      {
-        //convert from paths to Android friendly Parcelable Uri's
-        var file = new Java.IO.File(attachment);
-        if (file.Exists()) 
+        public static void AddAttachments(this Intent intent, IEnumerable<string> attachments, IEnumerable<string> fileProviders)
         {
-          Uri u = Uri.FromFile(file);
-          uris.Add(u);
-        } else {
-            Android.Util.Log.Warn("Intent.AddAttachments", "Unable to attach file '{0}', because it doesn't exist.", attachment);
-        }
-      }
+            if (attachments == null || !attachments.Any())
+            {
+                Android.Util.Log.Info("Intent.AddAttachments", "No attachments to attach.");
+                return;
+            } 
 
-      intent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
+            if ((fileProviders == null || !fileProviders.Any()) &&
+                Android.OS.Build.VERSION.SdkInt >= Android.OS.BuildVersionCodes.M)
+            {
+                Android.Util.Log.Warn("Intent.AddAttachments", "Android M's permission model requires attachments to be added with a FileProvider. Add one or more providers to the constructor.");
+            }
+
+            IList<IParcelable> uris = new List<IParcelable>();
+
+            foreach (var attachment in attachments)
+            {
+                var file = new Java.IO.File(attachment);
+
+                if (!file.Exists())
+                {
+                    Android.Util.Log.Warn("Intent.AddAttachments", "Unable to attach file '{0}', because it doesn't exist.", attachment);
+                    continue; // Go to the next file
+                }
+
+                Uri fileUri = null;
+
+                if (fileProviders != null && fileProviders.Any())
+                {
+                    foreach (var fileProvider in fileProviders)
+                    {
+                        try
+                        {
+                            fileUri = FileProvider.GetUriForFile(Android.App.Application.Context, fileProvider, file);
+                        }
+                        catch (Java.Lang.IllegalArgumentException)
+                        {
+                            // FileProvider can't deal with the file, go to the next if there is one
+                            continue;
+                        }
+
+                        if (fileUri != null)
+                        {
+                            break;
+                        }
+                    }
+                }
+                else
+                { // There is no fileprovider added, try normal procedure
+                    fileUri = Uri.FromFile(file);
+                }
+
+                if (fileUri != null)
+                {
+                    uris.Add(fileUri);
+                }
+                else
+                {
+                    //TODO: what to do if there are no providers that can deal with the file?
+                    Android.Util.Log.Warn("Intent.AddAttachments", "Unable to attach file '{0}', because there is no FileProvider that can deal with the file.", attachment);
+                }
+            }
+
+            intent.PutParcelableArrayListExtra(Intent.ExtraStream, uris);
+        }
     }
-  }
 }

--- a/src/Platform/XLabs.Platform.Droid/Services/Email/EmailService.cs
+++ b/src/Platform/XLabs.Platform.Droid/Services/Email/EmailService.cs
@@ -3,8 +3,8 @@
 // Author           : XLabs Team
 // Created          : 12-27-2015
 // 
-// Last Modified By : XLabs Team
-// Last Modified On : 01-04-2016
+// Last Modified By : Tim Klingeleers
+// Last Modified On : 03-27-2016
 // ***********************************************************************
 // <copyright file="EmailService.cs" company="XLabs Team">
 //     Copyright (c) XLabs Team. All rights reserved.
@@ -24,89 +24,96 @@ using Android.Content;
 
 namespace XLabs.Platform.Services.Email
 {
-	/// <summary>
-	/// Class EmailService.
-	/// </summary>
-	public class EmailService : IEmailService
-	{
-		#region IEmailService Members
+    /// <summary>
+    /// Class EmailService.
+    /// </summary>
+    public class EmailService : IEmailService
+    {
+        private IEnumerable<string> fileProviders;
 
-		// TODO: Check if there is a way to check this on Android
-		/// <summary>
-		/// Gets a value indicating whether this instance can send.
-		/// </summary>
-		/// <value><c>true</c> if this instance can send; otherwise, <c>false</c>.</value>
-		public bool CanSend
-		{
-			get { return true; }
-		}
+        public EmailService()
+        {
+        }
 
-		/// <summary>
-		/// Shows the draft.
-		/// </summary>
-		/// <param name="subject">The subject.</param>
-		/// <param name="body">The body.</param>
-		/// <param name="html">if set to <c>true</c> [HTML].</param>
-		/// <param name="to">To.</param>
-		/// <param name="cc">The cc.</param>
-		/// <param name="bcc">The BCC.</param>
-		/// <param name="attachments">The attachments.</param>
-		public void ShowDraft(string subject, string body, bool html, string[] to, string[] cc, string[] bcc, IEnumerable<string> attachments = null)
-		{
-			var intent = new Intent(Intent.ActionSendMultiple);
+        /// <summary>
+        /// Initializes a new instance of the <see cref="XLabs.Platform.Services.Email.EmailService"/> class.
+        /// </summary>
+        /// <param name="fileProviders">A list of file providers. 
+        /// Required as of Android M (API level 23) and higher.</param>
+        public EmailService(IEnumerable<string> fileProviders)
+        {
+            this.fileProviders = fileProviders;
+        }
 
-			intent.SetType(html ? "text/html" : "text/plain");
-			intent.PutExtra(Intent.ExtraEmail, to);
-			intent.PutExtra(Intent.ExtraCc, cc);
-			intent.PutExtra(Intent.ExtraBcc, bcc);
-			intent.PutExtra(Intent.ExtraSubject, subject ?? string.Empty);
+        #region IEmailService Members
 
-			if (html)
-			{
-				intent.PutExtra(Intent.ExtraText, Android.Text.Html.FromHtml(body));
-			}
-			else
-			{
-				intent.PutExtra(Intent.ExtraText, body ?? string.Empty);
-			}
+        // TODO: Check if there is a way to check this on Android
+        /// <summary>
+        /// Gets a value indicating whether this instance can send.
+        /// </summary>
+        /// <value><c>true</c> if this instance can send; otherwise, <c>false</c>.</value>
+        public bool CanSend
+        {
+            get { return true; }
+        }
 
-			if (attachments != null) 
-			{
-				intent.AddAttachments (attachments);
-			}
+        /// <summary>
+        /// Shows the draft.
+        /// </summary>
+        /// <param name="subject">The subject.</param>
+        /// <param name="body">The body.</param>
+        /// <param name="html">if set to <c>true</c> [HTML].</param>
+        /// <param name="to">To.</param>
+        /// <param name="cc">The cc.</param>
+        /// <param name="bcc">The BCC.</param>
+        /// <param name="attachments">The attachments.</param>
+        public void ShowDraft(string subject, string body, bool html, string[] to, string[] cc, string[] bcc, IEnumerable<string> attachments = null)
+        {
+            var intent = new Intent(Intent.ActionSendMultiple);
+            intent.AddFlags(ActivityFlags.GrantReadUriPermission);
 
-			this.StartActivity(intent);
-		}
+            intent.SetType(html ? "text/html" : "text/plain");
+            intent.PutExtra(Intent.ExtraEmail, to);
+            if (cc != null)
+            {
+                intent.PutExtra(Intent.ExtraCc, cc);
+            }
+            if (bcc != null)
+            {
+                intent.PutExtra(Intent.ExtraBcc, bcc);
+            }
+            intent.PutExtra(Intent.ExtraSubject, subject ?? string.Empty);
 
-		/// <summary>
-		/// Shows the draft.
-		/// </summary>
-		/// <param name="subject">The subject.</param>
-		/// <param name="body">The body.</param>
-		/// <param name="html">if set to <c>true</c> [HTML].</param>
-		/// <param name="to">To.</param>
-		/// <param name="attachments">The attachments.</param>
-		public void ShowDraft(string subject, string body, bool html, string to, IEnumerable<string> attachments = null)
-		{
-			var intent = new Intent(Intent.ActionSendMultiple);
-			intent.SetType(html ? "text/html" : "text/plain");
-			intent.PutExtra(Intent.ExtraEmail, new string[]{ to });
-			intent.PutExtra(Intent.ExtraSubject, subject ?? string.Empty);
+            if (html)
+            {
+                intent.PutExtra(Intent.ExtraText, Android.Text.Html.FromHtml(body));
+            }
+            else
+            {
+                intent.PutExtra(Intent.ExtraText, body ?? string.Empty);
+            }
 
-			if (html)
-			{
-				intent.PutExtra(Intent.ExtraText, body);
-			}
-			else
-			{
-				intent.PutExtra(Intent.ExtraText, body ?? string.Empty);
-			}
+            if (attachments != null)
+            {
+                intent.AddAttachments(attachments, fileProviders);
+            }
 
-			intent.AddAttachments(attachments);
+            this.StartActivity(intent);
+        }
 
-			this.StartActivity(intent);
-		}
+        /// <summary>
+        /// Shows the draft.
+        /// </summary>
+        /// <param name="subject">The subject.</param>
+        /// <param name="body">The body.</param>
+        /// <param name="html">if set to <c>true</c> [HTML].</param>
+        /// <param name="to">To.</param>
+        /// <param name="attachments">The attachments.</param>
+        public void ShowDraft(string subject, string body, bool html, string to, IEnumerable<string> attachments = null)
+        {
+            ShowDraft(subject, body, html, new string[] { to }, null, null, attachments);
+        }
 
-		#endregion
-	}
+        #endregion
+    }
 }

--- a/src/Platform/XLabs.Platform.Droid/XLabs.Platform.Droid.csproj
+++ b/src/Platform/XLabs.Platform.Droid/XLabs.Platform.Droid.csproj
@@ -45,6 +45,9 @@
       <HintPath>..\..\..\packages\ExifLib.PCL.1.0.1\lib\portable-net45+sl50+win+WindowsPhoneApp81+wp80+Xamarin.iOS10+MonoAndroid10+MonoTouch10\ExifLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Xamarin.Android.Support.v4">
+      <HintPath>..\..\..\packages\Xamarin.Android.Support.v4.23.0.1.3\lib\MonoAndroid403\Xamarin.Android.Support.v4.dll</HintPath>
+    </Reference>
     <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
     <Reference Include="System" />

--- a/src/Platform/XLabs.Platform.Droid/packages.config
+++ b/src/Platform/XLabs.Platform.Droid/packages.config
@@ -2,4 +2,5 @@
 <packages>
   <package id="ExifLib.PCL" version="1.0.1" targetFramework="MonoAndroid50" />
   <package id="NuProj.Common" version="0.10.4-beta" targetFramework="monoandroid60" developmentDependency="true" />
+  <package id="Xamarin.Android.Support.v4" version="23.0.1.3" targetFramework="MonoAndroid60" />
 </packages>


### PR DESCRIPTION
Because Android M and higher adds a new permission model, it requires you to start using FileProviders. When you don't use them, depending on your Email client it will ask you for specific permissions, or just not work at all.

It first checks if there are attachments to add, and if ran on Android M or higher outputs a log warning that mentions the developer should use FileProviders.

This solution requires the use of Android Support Library v4 (FileProvider). That's the reason this reference is added.

fixes #1110 

It isn't really obvious to users that this problem occurs, since the Android Log Warnings get overlooked very easily.

Please review. Tested on a Nexus 6P, but an emulator should also work given there is an email client/account configured. 
