### PR TITLE
Make mono script compatible.

### DIFF
--- a/tools/settingsUtils.cake
+++ b/tools/settingsUtils.cake
@@ -10,9 +10,9 @@ public class SettingsUtils
 			context.Error("Settings File Does Not Exist");
 			return null;
 		}
-		
+
 		var obj = context.DeserializeJsonFromFile<Settings>(settingsFile);
-		
+
 		return obj;
 	}
 }
@@ -22,7 +22,7 @@ public class Settings
 	public VersionSettings Version {get;set;}
 	public BuildSettings Build {get;set;}
 	public NuGetSettings NuGet {get;set;}
-	
+
 	public void Display(ICakeContext context)
 	{
 		context.Information("Settings:");
@@ -38,14 +38,14 @@ public class VersionSettings
 	{
 		LoadFrom = "VersionFile";
 	}
-	
+
 	public string VersionFile {get;set;}
 	public string AssemblyInfoFile {get;set;}
 	public bool LoadFromGit {get;set;}
 	public string LoadFrom {get;set;}
 	public bool AutoIncrementVersion {get;set;}
 	public string NamespaceBase {get;set;}
-	
+
 	public void Display(ICakeContext context)
 	{
 		context.Information("Version Settings:");
@@ -67,25 +67,25 @@ public class BuildSettings
 		NugetConfigPath = "./.nuget/NuGet.Config";
 		EnableXamarinIOS = false;
 	}
-	
+
 	public string SourcePath {get;set;}
 	public string SolutionFileSpec {get;set;}
 	public bool TreatWarningsAsErrors {get;set;}
 	public string NugetConfigPath {get;set;}
-	
+
 	public bool EnableXamarinIOS {get;set;}
 	public string MacAgentIPAddress {get;set;}
 	public string MacAgentUserName {get;set;}
 	public string MacAgentUserPassword {get;set;}
-	
+
 	public string SolutionFilePath {
 		get {
 			if (SolutionFileSpec.Contains("/")) return SolutionFileSpec;
-			
+
 			return string.Format("{0}{1}{2}", SourcePath, SolutionFileSpec.Contains("*") ? "/**/" : "", SolutionFileSpec);
 		}
 	}
-	
+
 	public void Display(ICakeContext context)
 	{
 		context.Information("Build Settings:");
@@ -94,7 +94,7 @@ public class BuildSettings
 		context.Information("\tSolution File Path: {0}", SolutionFilePath);
 		context.Information("\tTreat Warnings As Errors: {0}", TreatWarningsAsErrors);
 		context.Information("\tNuget Config Path: {0}", NugetConfigPath);
-		
+
 		context.Information("\tEnable Xamarin IOS: {0}", EnableXamarinIOS);
 		context.Information("\tMac Agent IP Address: {0}", MacAgentIPAddress);
 		context.Information("\tMac Agent User Name: {0}", MacAgentUserName);
@@ -120,7 +120,7 @@ public class NuGetSettings
 	public string ArtifactsPath {get;set;}
 	public bool UpdateVersion {get;set;}
 	public VersionDependencyTypes VersionDependencyForLibrary {get;set;}
-	
+
 	public string NuSpecFileSpec {
 		get {
 			return string.Format("{0}/**/*.nuspec", NuSpecPath);
@@ -132,7 +132,7 @@ public class NuGetSettings
 			return string.Format("{0}/*.nupkg", ArtifactsPath);
 		}
 	}
-	
+
 	public void Display(ICakeContext context)
 	{
 		context.Information("NuGet Settings:");
@@ -148,10 +148,20 @@ public class NuGetSettings
 	}
 }
 
-public enum VersionDependencyTypes {
-	none,
-	exact,
-	greaterthan,
-	greaterthanorequal,
-	lessthan
+public class VersionDependencyTypes
+{
+	public string Value { get; set; }
+	public VersionDependencyTypes(string value)
+	{
+		Value = value;
+	}
+
+	public static implicit operator string(VersionDependencyTypes x) {return x.Value;}
+	public static implicit operator VersionDependencyTypes(String text) {return new VersionDependencyTypes(text);}
+
+	public static VersionDependencyTypes none = new VersionDependencyTypes("none");
+	public static VersionDependencyTypes exact = new VersionDependencyTypes("exact");
+	public static VersionDependencyTypes greaterthan = new VersionDependencyTypes("greaterthan");
+	public static VersionDependencyTypes greaterthanorequal = new VersionDependencyTypes("greaterthanorequal");
+	public static VersionDependencyTypes lessthan = new VersionDependencyTypes("lessthan");
 }

--- a/tools/versionUtils.cake
+++ b/tools/versionUtils.cake
@@ -7,36 +7,36 @@ public class VersionUtils
 {
 	public static VersionInfo LoadVersion(ICakeContext context, Settings settings)
 	{
-        if (context == null)
-        {
-            throw new ArgumentNullException("context");
-        }
+		if (context == null)
+		{
+			throw new ArgumentNullException("context");
+		}
 
 		VersionInfo verInfo = null;
-		
+
 		if (!string.IsNullOrEmpty(settings.Version.VersionFile) && context.FileExists(settings.Version.VersionFile))
 		{
 			verInfo = LoadVersionFromJson(context, settings.Version.VersionFile);
 		}
-		
+
 		if (verInfo == null && !string.IsNullOrEmpty(settings.Version.AssemblyInfoFile) && context.FileExists(settings.Version.AssemblyInfoFile))
 		{
 			verInfo = LoadVersionFromAssemblyInfo(context, settings.Version.AssemblyInfoFile);
 		}
-		
+
 		if (verInfo == null && settings.Version.LoadFromGit)
 		{
 			verInfo = LoadVersionFromGit(context);
 		}
-		
+
 		if (verInfo != null)
 		{
 			verInfo.CakeVersion = typeof(ICakeContext).Assembly.GetName().Version.ToString();
 		}
-		
+
 		return verInfo;
 	}
-	
+
 	private static VersionInfo LoadVersionFromJson(ICakeContext context, string versionFile)
 	{
 		context.Information("Loading Version Info From File: {0}", versionFile);
@@ -45,16 +45,16 @@ public class VersionUtils
 			context.Error("Version File Does Not Exist");
 			return null;
 		}
-		
+
 		var obj = context.DeserializeJsonFromFile<VersionInfo>(versionFile);
-		
+
 		return obj;
 	}
-	
+
 	private static VersionInfo LoadVersionFromAssemblyInfo(ICakeContext context, string assemblyInfoFile)
 	{
 		context.Information("Fetching Version Info from AssemblyInfo File: {0}", assemblyInfoFile);
-		
+
 		if (!context.FileExists(assemblyInfoFile))
 		{
 			context.Error("AssemblyInfo file does not exist");
@@ -64,7 +64,7 @@ public class VersionUtils
 		try {
 			var assemblyInfo = context.ParseAssemblyInfo(assemblyInfoFile);
 			var v = Version.Parse(assemblyInfo.AssemblyVersion);
-			
+
 			var verInfo = new VersionInfo {
 				Major = v.Major,
 				Minor = v.Minor,
@@ -72,14 +72,14 @@ public class VersionUtils
 				Semantic = assemblyInfo.AssemblyInformationalVersion,
 				Milestone = string.Concat("v", v.ToString())
 			};
-			
+
 			return verInfo;
 		}
 		catch {}
-		
+
 		return null;
 	}
-	
+
 	private static VersionInfo LoadVersionFromGit(ICakeContext context)
 	{
 		context.Information("Fetching Verson Infop from Git");
@@ -88,7 +88,7 @@ public class VersionUtils
 			GitVersion assertedVersions = context.GitVersion(new GitVersionSettings
 			{
 				OutputType = GitVersionOutput.Json,
-			});
+				});
 
 			var verInfo = new VersionInfo {
 				Major = assertedVersions.Major,
@@ -101,85 +101,85 @@ public class VersionUtils
 			context.Information("Calculated Semantic Version: {0}", verInfo.Semantic);
 
 			return verInfo;
-		} catch {}
+			} catch {}
 
-		return null;
-	}
-	
-	public static void UpdateVersion(ICakeContext context, Settings settings, VersionInfo verInfo)
-	{
-        if (context == null)
-        {
-            throw new ArgumentNullException("context");
-        }
-
-		if (!string.IsNullOrEmpty(settings.Version.VersionFile) && context.FileExists(settings.Version.VersionFile))
-		{	
-			context.Information("Updating Version File {0}", settings.Version.VersionFile);
-			
-			context.SerializeJsonToFile(settings.Version.VersionFile, verInfo);
+			return null;
 		}
-		
-		if (!string.IsNullOrEmpty(settings.Version.AssemblyInfoFile) && context.FileExists(settings.Version.AssemblyInfoFile))
+
+		public static void UpdateVersion(ICakeContext context, Settings settings, VersionInfo verInfo)
 		{
-			context.Information("Updating Assembly Info File {0}", settings.Version.AssemblyInfoFile);
-			
-			context.ReplaceRegexInFiles(settings.Version.AssemblyInfoFile, "AssemblyVersion\\(.*\\)", string.Format("AssemblyVersion(\"{0}\")", verInfo.ToString(false)));
-			context.ReplaceRegexInFiles(settings.Version.AssemblyInfoFile, "AssemblyFileVersion\\(.*\\)", string.Format("AssemblyFileVersion(\"{0}\")", verInfo.ToString(false)));
+			if (context == null)
+			{
+				throw new ArgumentNullException("context");
+			}
+
+			if (!string.IsNullOrEmpty(settings.Version.VersionFile) && context.FileExists(settings.Version.VersionFile))
+			{
+				context.Information("Updating Version File {0}", settings.Version.VersionFile);
+
+				context.SerializeJsonToFile(settings.Version.VersionFile, verInfo);
+			}
+
+			if (!string.IsNullOrEmpty(settings.Version.AssemblyInfoFile) && context.FileExists(settings.Version.AssemblyInfoFile))
+			{
+				context.Information("Updating Assembly Info File {0}", settings.Version.AssemblyInfoFile);
+
+				context.ReplaceRegexInFiles(settings.Version.AssemblyInfoFile, "AssemblyVersion\\(.*\\)", string.Format("AssemblyVersion(\"{0}\")", verInfo.ToString(false)));
+				context.ReplaceRegexInFiles(settings.Version.AssemblyInfoFile, "AssemblyFileVersion\\(.*\\)", string.Format("AssemblyFileVersion(\"{0}\")", verInfo.ToString(false)));
+			}
 		}
-	}
 
-	public static void UpdateNuSpecVersion(ICakeContext context, Settings settings, VersionInfo verInfo, FilePath nuspecFile)
-	{
-        if (context == null)
-        {
-            throw new ArgumentNullException("context");
-        }
+		public static void UpdateNuSpecVersion(ICakeContext context, Settings settings, VersionInfo verInfo, FilePath nuspecFile)
+		{
+			if (context == null)
+			{
+				throw new ArgumentNullException("context");
+			}
 
-		var xpq = string.Format("/n:package/n:metadata/n:version");
-		
-		context.Information("\tUpdating Version in Nuspec File {0} to {1}", nuspecFile, verInfo.ToString());
-		
-		try {
-			context.XmlPoke(nuspecFile, xpq, verInfo.ToString(), new XmlPokeSettings {
-				PreserveWhitespace = true
-				, Namespaces = new Dictionary<string, string> {
-					 { /* Prefix */ "n", /* URI */ "http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"}
-				 }
-			});
+			var xpq = string.Format("/n:package/n:metadata/n:version");
+
+			context.Information("\tUpdating Version in Nuspec File {0} to {1}", nuspecFile, verInfo.ToString());
+
+			try {
+				context.XmlPoke(nuspecFile, xpq, verInfo.ToString(), new XmlPokeSettings {
+					PreserveWhitespace = true
+					, Namespaces = new Dictionary<string, string> {
+						{ /* Prefix */ "n", /* URI */ "http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"}
+					}
+					});
 		} catch {} // Its ok to throw these away as it most likely means the file didn't exist or the XPath didn't find any nodes
 	}
-	
+
 	public static void UpdateNuSpecVersionDependency(ICakeContext context, Settings settings, VersionInfo verInfo, FilePath nuspecFile)
 	{
-        if (context == null)
-        {
-            throw new ArgumentNullException("context");
-        }
+		if (context == null)
+		{
+			throw new ArgumentNullException("context");
+		}
 
 		if (string.IsNullOrEmpty(settings.Version.NamespaceBase)) return;
-		
+
 		var xpq = string.Format("/n:package/n:metadata/n:dependencies//n:dependency[starts-with(@id, '{0}')]/@version", settings.Version.NamespaceBase);
 		var replacementStr = verInfo.ToString();
 
 		switch (settings.NuGet.VersionDependencyForLibrary)
 		{
-			case VersionDependencyTypes.none: break;
-			case VersionDependencyTypes.exact: replacementStr = string.Format("[{0}]", replacementStr); break;
-			case VersionDependencyTypes.greaterthan: replacementStr = string.Format("(,{0})", replacementStr); break;
-			case VersionDependencyTypes.greaterthanorequal: replacementStr = string.Format("(,{0}]", replacementStr); break;
-			case VersionDependencyTypes.lessthan: replacementStr = string.Format("({0},)", replacementStr); break;
+			case "none": break;
+			case "exact": replacementStr = string.Format("[{0}]", replacementStr); break;
+			case "greaterthan": replacementStr = string.Format("(,{0})", replacementStr); break;
+			case "greaterthanorequal": replacementStr = string.Format("(,{0}]", replacementStr); break;
+			case "lessthan": replacementStr = string.Format("({0},)", replacementStr); break;
 		}
-		
+
 		context.Information("\tUpdating Version for {0} Namespace Assemblies in Nuspec File {1} to {2}", settings.Version.NamespaceBase, nuspecFile, replacementStr);
-		
+
 		try {
 			context.XmlPoke(nuspecFile, xpq, replacementStr, new XmlPokeSettings {
 				PreserveWhitespace = true
 				, Namespaces = new Dictionary<string, string> {
-					 { /* Prefix */ "n", /* URI */ "http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"}
-				 }
-			});
+					{ /* Prefix */ "n", /* URI */ "http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd"}
+				}
+				});
 		} catch {} // Its ok to throw these away as it most likely means the file didn't exist or the XPath didn't find any nodes
 	}
 }
@@ -203,18 +203,18 @@ public class VersionInfo
 	public string Milestone {get;set;}
 	[Newtonsoft.Json.JsonIgnore]
 	public string CakeVersion {get;set;}
-	
+
 	[Newtonsoft.Json.JsonIgnore]
 	public bool IsPreRelease { get { return PreRelease != null && PreRelease != 0; } }
 
-	public new string ToString(bool includePreRelease = true) 
-	{ 
+	public string ToString(bool includePreRelease = true)
+	{
 		var str = string.Format("{0:#0}.{1:#0}.{2:#0}", Major, Minor, Build);
 		if (IsPreRelease && includePreRelease) str += string.Format("-pre{0:00}", PreRelease);
 
-		return str; 
+		return str;
 	}
-	
+
 	public void Display(ICakeContext context)
 	{
 		context.Information("Version:");
@@ -226,7 +226,7 @@ public class VersionInfo
 		context.Information("\tSemantic: {0}", Semantic);
 		context.Information("\tMilestone: {0}", Milestone);
 		context.Information("\tCake Version: {0}", CakeVersion);
-		
+
 		if (ReleaseNotes != null) context.Information("\tRelease Notes: {0}", ReleaseNotes);
 	}
 }


### PR DESCRIPTION
* new keyword not needed it doesn't replace any base method
* mono script doesn't support enums, so changed to class/static properties instead