### PR TITLE
iPhone6 & iPhone6+ zoom mode detection

### DIFF
--- a/src/Platform/XLabs.Platform.iOS/Device/Phone.cs
+++ b/src/Platform/XLabs.Platform.iOS/Device/Phone.cs
@@ -20,6 +20,8 @@
 // 
 
 using System.ComponentModel;
+using CoreGraphics;
+using UIKit;
 using XLabs.Platform.Extensions;
 using XLabs.Platform.Services;
 

--- a/src/Platform/XLabs.Platform.iOS/Device/Phone.cs
+++ b/src/Platform/XLabs.Platform.iOS/Device/Phone.cs
@@ -194,9 +194,19 @@ namespace XLabs.Platform.Device
             int height;
             if (UIKit.UIDevice.CurrentDevice.CheckSystemVersion(8, 0))
             {
-                CoreGraphics.CGRect bounds = UIKit.UIScreen.MainScreen.NativeBounds;
-                width = (int)bounds.Width;
-                height = (int)bounds.Height;
+                // MainScreen.CurrentMode will reflect zoom mode on iOS8+
+                CGSize size = UIScreen.MainScreen.CurrentMode.Size;
+                if((Version == PhoneType.IPhone6 && size.Height == 1136) || (Version == PhoneType.IPhone6Plus && size.Height == 2001))
+                {
+                    width = (int)size.Width / (int)UIKit.UIScreen.MainScreen.Scale;
+                    height = (int)size.Height / (int)UIKit.UIScreen.MainScreen.Scale;
+                }
+                else
+                {
+                    CoreGraphics.CGRect bounds = UIKit.UIScreen.MainScreen.NativeBounds;
+                    width = (int)bounds.Width;
+                    height = (int)bounds.Height;
+                }
             }
             else
             {


### PR DESCRIPTION
There appears to be an issue detecting zoom mode on the iPhone6 and iPhone6+. 
I've added detection for zoom mode via UIScreen.MainScreen.CurrentMode.Size.

This issue does not appear to exist on the iPhone6S and iPhone6S+ and this issue can not be replicated on the simulator.
Here's how to activate zoom mode: https://support.apple.com/en-us/HT203073

I'm not sure if this is the most proper fix for this issue but I haven't been able to locate a better way to do this. Let me know if you have any feedback please. Thanks!
