### PR TITLE
Added support for no border ExtenedEntry on Android

### DIFF
--- a/src/Forms/XLabs.Forms.Droid/Controls/ExtendedEntry/ExtendedEntryRenderer.cs
+++ b/src/Forms/XLabs.Forms.Droid/Controls/ExtendedEntry/ExtendedEntryRenderer.cs
@@ -43,6 +43,8 @@ namespace XLabs.Forms.Controls
         private const int MinDistance = 10;
 
         private float downX, downY, upX, upY;
+        
+        private Drawable originalBackground;
 
         /// <summary>
         /// Called when [element changed].
@@ -59,6 +61,9 @@ namespace XLabs.Forms.Controls
                 Control.SetTypeface(Typeface.Default, TypefaceStyle.Normal);
                 Control.TransformationMethod = new PasswordTransformationMethod();
             }
+            
+            if (originalBackground == null)
+                originalBackground = Control.Background;
 
             SetFont(view);
             SetTextAlignment(view);
@@ -180,10 +185,20 @@ namespace XLabs.Forms.Controls
         ///// Sets the border.
         ///// </summary>
         ///// <param name="view">The view.</param>
-        //private void SetBorder(ExtendedEntry view)
-        //{
-        //    //NotCurrentlySupported: HasBorder peroperty not suported on Android
-        //}
+        private void SetBorder(ExtendedEntry view)
+        {
+           if (view.HasBorder == false)
+           {
+                var shape = new ShapeDrawable(new RectShape());
+                shape.Paint.Alpha = 0;
+                shape.Paint.SetStyle(Paint.Style.Stroke);
+                Control.SetBackgroundDrawable(shape);
+           }
+           else 
+           {
+               Control.SetBackground (originalBackground);
+           }
+        }
 
         /// <summary>
         /// Sets the text alignment.


### PR DESCRIPTION
Manipulating the Entry Background we are able to remove its borders.
It's quite a simple solution, not sure if it will crash backward compatibility.

Tested with: 
Xamarin.Forms 2.3.2.1127
Xamarin.Android.Support.v4 23.4.0.1
Target: Android API 23
