### PR TITLE
fix RadioButton/BindableRadioGroup.cs

### DIFF
--- a/src/Forms/XLabs.Forms/Controls/RadioButton/BindableRadioGroup.cs
+++ b/src/Forms/XLabs.Forms/Controls/RadioButton/BindableRadioGroup.cs
@@ -56,7 +56,7 @@ namespace XLabs.Forms.Controls
         /// The selected index property
         /// </summary>
         public static BindableProperty SelectedIndexProperty =
-            BindableProperty.Create<BindableRadioGroup, int>(o => o.SelectedIndex, default(int), BindingMode.TwoWay,
+            BindableProperty.Create<BindableRadioGroup, int>(o => o.SelectedIndex, -1, BindingMode.TwoWay,
                 propertyChanged: OnSelectedIndexChanged);
 
 


### PR DESCRIPTION
If your ItemSource contain an element with id = 0 it is not being checked on view load because OnSelectedItemChanged is not being fired. 

That's a problem with default bindableproperty value - it is 0 so app have no idea if the property has been changed.