### PR TITLE
Update CalendarMonthView.cs

### DIFF
--- a/src/Forms/XLabs.Forms.iOS/Controls/Calendar/CalendarMonthView.cs
+++ b/src/Forms/XLabs.Forms.iOS/Controls/Calendar/CalendarMonthView.cs
@@ -565,26 +565,32 @@ namespace XLabs.Forms.Controls
 
             Action action = () =>
             {
-                if (isMin && _leftArrow.Enabled)
+                if(_leftArrow != null) 
                 {
-                    _leftArrow.Enabled = false;
-                    _leftArrow.Alpha = 0;
-                }
-                else
-                {
-                    _leftArrow.Enabled = true;
-                    _leftArrow.Alpha = 1;
+                    if (isMin && _leftArrow.Enabled)
+                    {
+                        _leftArrow.Enabled = false;
+                        _leftArrow.Alpha = 0;
+                    }
+                    else
+                    {
+                        _leftArrow.Enabled = true;
+                        _leftArrow.Alpha = 1;
+                    }
                 }
 
-                if (isMax && _rightArrow.Enabled)
+                if(_rightArrow != null) 
                 {
-                    _rightArrow.Enabled = false;
-                    _rightArrow.Alpha = 0;
-                }
-                else
-                {
-                    _rightArrow.Enabled = true;
-                    _rightArrow.Alpha = 1;
+                    if (isMax && _rightArrow.Enabled)
+                    {
+                        _rightArrow.Enabled = false;
+                        _rightArrow.Alpha = 0;
+                    }
+                    else
+                    {
+                        _rightArrow.Enabled = true;
+                        _rightArrow.Alpha = 1;
+                    }
                 }
             };
 


### PR DESCRIPTION
It happens that the action is launched and the arrows are not created. That crashes the app without notice.

For me it happens always when I interact with the calendar (in day mode), and hide it (change of tab in a tabbedview).