### PR TITLE
Add Radio Button for Windows

### DIFF
--- a/src/Forms/XLabs.Forms.WinRT.Shared/Controls/RadioButton/RadioButtonRenderer.cs
+++ b/src/Forms/XLabs.Forms.WinRT.Shared/Controls/RadioButton/RadioButtonRenderer.cs
@@ -1,0 +1,112 @@
+// ***********************************************************************
+// Assembly         : XLabs.Forms.WinRT.Forms
+// Author           : XLabs Team
+// Created          : 12-31-2014
+// 
+// Last Modified By : Eli Black
+// Last Modified On : 02-17-2017
+// ***********************************************************************
+// <copyright file="RadioButtonRenderer.cs" company="XLabs Team">
+//     Copyright (c) XLabs Team. All rights reserved.
+// </copyright>
+// <summary>
+//       This project is licensed under the Apache 2.0 license
+//       https://github.com/XLabs/Xamarin-Forms-Labs/blob/master/LICENSE
+//       
+//       XLabs is a open source project that aims to provide a powerfull and cross 
+//       platform set of controls tailored to work with Xamarin Forms.
+// </summary>
+// ***********************************************************************
+// 
+
+using System.ComponentModel;
+using Xamarin.Forms;
+using XLabs.Forms.Controls;
+
+#if WINDOWS_PHONE
+using Xamarin.Forms.Platform.WinPhone;
+
+#elif WINDOWS_APP || WINDOWS_PHONE_APP
+using Xamarin.Forms.Platform.WinRT;
+
+#elif NETFX_CORE
+using Xamarin.Forms.Platform.UWP;
+#endif
+
+using NativeRadioButton = Windows.UI.Xaml.Controls.RadioButton;
+
+[assembly: ExportRenderer(typeof(CustomRadioButton), typeof(RadioButtonRenderer))]
+
+namespace XLabs.Forms.Controls
+{
+    public class RadioButtonRenderer : ViewRenderer<CustomRadioButton, Windows.UI.Xaml.Controls.RadioButton>
+    {
+        protected override void OnElementChanged(ElementChangedEventArgs<CustomRadioButton> e)
+        {
+            base.OnElementChanged(e);
+
+            if (e.OldElement != null)
+            {
+                e.OldElement.CheckedChanged -= CheckedChanged;
+            }
+
+            if(e.NewElement == null)
+            {
+                return;
+            }
+
+            if (this.Control == null)
+            {
+                var radioButton = new NativeRadioButton();
+                radioButton.Checked += (s, args) => this.Element.Checked = true;
+                radioButton.Unchecked += (s, args) => this.Element.Checked = false;
+
+                this.SetNativeControl(radioButton);
+            }
+
+            this.Control.Content = e.NewElement.Text;
+            this.Control.IsChecked = e.NewElement.Checked;
+
+
+            this.Element.CheckedChanged += CheckedChanged;
+            this.Element.PropertyChanged += ElementOnPropertyChanged;
+        }
+
+        private void ElementOnPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)
+        {
+            NativeRadioButton control = this.Control;
+
+            if (control == null)
+            {
+                return;
+            }
+
+            switch (propertyChangedEventArgs.PropertyName)
+            {
+                case "Checked":
+                    control.IsChecked = this.Element.Checked;
+                    break;
+                case "TextColor":
+                    //control.Foreground = this.Element.TextColor ToBrush();
+                    break;
+                case "Text":
+                    control.Content = Element.Text;
+                    break;
+                default:
+                    System.Diagnostics.Debug.WriteLine("Property change for {0} has not been implemented.", propertyChangedEventArgs.PropertyName);
+                    break;
+            }
+        }
+
+        private void CheckedChanged(object sender, EventArgs<bool> eventArgs)
+        {
+            Device.BeginInvokeOnMainThread(() =>
+            {
+                this.Control.Content = this.Element.Text;
+                this.Control.IsChecked = eventArgs.Value;
+            });
+        }
+
+
+    }
+}

--- a/src/Forms/XLabs.Forms.WinRT.Shared/Controls/RadioButton/RadioButtonRenderer.cs
+++ b/src/Forms/XLabs.Forms.WinRT.Shared/Controls/RadioButton/RadioButtonRenderer.cs
@@ -22,6 +22,7 @@
 using System.ComponentModel;
 using Xamarin.Forms;
 using XLabs.Forms.Controls;
+using Windows.UI.Xaml.Media;
 
 #if WINDOWS_PHONE
 using Xamarin.Forms.Platform.WinPhone;
@@ -39,7 +40,7 @@ using NativeRadioButton = Windows.UI.Xaml.Controls.RadioButton;
 
 namespace XLabs.Forms.Controls
 {
-    public class RadioButtonRenderer : ViewRenderer<CustomRadioButton, Windows.UI.Xaml.Controls.RadioButton>
+    public class RadioButtonRenderer : ViewRenderer<CustomRadioButton, NativeRadioButton>
     {
         protected override void OnElementChanged(ElementChangedEventArgs<CustomRadioButton> e)
         {
@@ -55,26 +56,27 @@ namespace XLabs.Forms.Controls
                 return;
             }
 
-            if (this.Control == null)
+            if (Control == null)
             {
                 var radioButton = new NativeRadioButton();
-                radioButton.Checked += (s, args) => this.Element.Checked = true;
-                radioButton.Unchecked += (s, args) => this.Element.Checked = false;
+                radioButton.Checked += (s, args) => Element.Checked = true;
+                radioButton.Unchecked += (s, args) => Element.Checked = false;
 
-                this.SetNativeControl(radioButton);
+                SetNativeControl(radioButton);
             }
 
-            this.Control.Content = e.NewElement.Text;
-            this.Control.IsChecked = e.NewElement.Checked;
+            Control.Content = e.NewElement.Text;
+            Control.IsChecked = e.NewElement.Checked;
 
+            UpdateFont();
 
-            this.Element.CheckedChanged += CheckedChanged;
-            this.Element.PropertyChanged += ElementOnPropertyChanged;
+            Element.CheckedChanged += CheckedChanged;
+            Element.PropertyChanged += ElementOnPropertyChanged;
         }
 
         private void ElementOnPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)
         {
-            NativeRadioButton control = this.Control;
+            NativeRadioButton control = Control;
 
             if (control == null)
             {
@@ -84,10 +86,14 @@ namespace XLabs.Forms.Controls
             switch (propertyChangedEventArgs.PropertyName)
             {
                 case "Checked":
-                    control.IsChecked = this.Element.Checked;
+                    control.IsChecked = Element.Checked;
                     break;
                 case "TextColor":
-                    //control.Foreground = this.Element.TextColor ToBrush();
+                    control.Foreground = Element.TextColor.ToBrush();
+                    break;
+                case "FontName":
+                case "FontSize":
+                    UpdateFont();
                     break;
                 case "Text":
                     control.Content = Element.Text;
@@ -102,11 +108,22 @@ namespace XLabs.Forms.Controls
         {
             Device.BeginInvokeOnMainThread(() =>
             {
-                this.Control.Content = this.Element.Text;
-                this.Control.IsChecked = eventArgs.Value;
+                Control.Content = Element.Text;
+                Control.IsChecked = eventArgs.Value;
             });
         }
 
-
+        /// <summary>
+        /// Updates the font.
+        /// </summary>
+        private void UpdateFont()
+        {
+            if (!string.IsNullOrEmpty(Element.FontName))
+            {
+                Control.FontFamily = new FontFamily(Element.FontName);
+            }
+ 
+            Control.FontSize = (Element.FontSize > 0) ? (float)Element.FontSize : 12.0f;
+        }
     }
 }

--- a/src/Forms/XLabs.Forms.WinRT.Shared/XLabs.Forms.WinRT.Shared.projitems
+++ b/src/Forms/XLabs.Forms.WinRT.Shared/XLabs.Forms.WinRT.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\CheckBox\CheckBoxRenderer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\HybridWebView\HybridWebViewRenderer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ImageButton\ImageButtonRenderer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\RadioButton\RadioButtonRenderer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\AlignmentExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ColorExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\FontExtensions.cs" />


### PR DESCRIPTION
This commit adds the radio button control for Windows. It appears that this control was previously included for WindowsPhone, but was later dropped. This a port of that code from WindowsPhone to Windows.

You can find the original file [here](https://github.com/XLabs/Xamarin-Forms-Labs/commits/4d7d5568bc791d8693bf2ac87d19c6cd8429a210/src/Forms/XLabs.Forms.WP8/Controls/RadioButton/RadioButtonRenderer.cs).

I've tested and have this working in one of my projects.