### PR TITLE
Change ItemSelected to ItemTapped

### DIFF
--- a/src/Forms/XLabs.Forms/Controls/AutoCompleteView.cs
+++ b/src/Forms/XLabs.Forms/Controls/AutoCompleteView.cs
@@ -202,13 +202,13 @@ namespace XLabs.Forms.Controls
                     SearchCommand.Execute(Text);
                 }
             };
-            _lstSuggestions.ItemSelected += (s, e) =>
+            _lstSuggestions.ItemTapped += (s, e) =>
             {
-                _entText.Text = e.SelectedItem.ToString();
+                _entText.Text = e.Item.ToString();
 
                 _availableSuggestions.Clear();
                 ShowHideListbox(false);
-                OnSelectedItemChanged(e.SelectedItem);
+                OnSelectedItemChanged(e.Item);
 
                 if (ExecuteOnSuggestionClick
                    && SearchCommand != null


### PR DESCRIPTION
with the ItemSelected when the user selected an item clear the text and select the same item again the list view will not collapse because item is not changed. Change it to ItemTapped fixed this.